### PR TITLE
Calm workspace commands fix ci errors

### DIFF
--- a/calm-hub/README.md
+++ b/calm-hub/README.md
@@ -214,18 +214,18 @@ at [http://localhost:8080/q/dev-ui](http://localhost:8080/q/dev-ui).
 
 #### Enabling / disabling
 
-The whole MCP surface is gated by a single config property (default `true`):
+MCP is an **experimental feature** and is disabled by default. `calm.mcp.enabled` gates **tool invocations** — when `false`, every `@Tool` method returns a disabled error to the MCP client. The `/mcp` HTTP endpoint itself remains reachable regardless of this flag; network-level controls or authentication are needed to restrict endpoint access.
 
 ```properties
-calm.mcp.enabled=true
+calm.mcp.enabled=false
 ```
 
-Disable it from the command line or environment:
+Enable it from the command line or environment:
 
 ```shell
-../mvnw quarkus:dev -Dcalm.mcp.enabled=false
+../mvnw quarkus:dev -Dcalm.mcp.enabled=true
 # or
-export CALM_MCP_ENABLED=false
+export CALM_MCP_ENABLED=true
 ```
 
 #### Exposing your local MCP via ngrok
@@ -249,7 +249,7 @@ local CalmHub:
 
 The ngrok URL changes each session unless you use a reserved domain.
 
-> **⚠ Security note** — under the default profile the MCP endpoint runs
+> **⚠ Security note** — when enabled, under the default profile the MCP endpoint runs
 > **without authentication**, the same as the default-profile REST API. The
 > `secure` profile enforces JWT authentication on `/mcp/*` (see
 > `application-secure.properties`), but does **not** yet apply per-tool
@@ -258,8 +258,8 @@ The ngrok URL changes each session unless you use a reserved domain.
 > follow-up. Exposing CalmHub through ngrok publishes the endpoint to the
 > public internet, so when demoing protect the tunnel with ngrok-side controls
 > (for example `ngrok http 8080 --basic-auth 'user:password'`, an OAuth edge,
-> or an IP allowlist), tear the tunnel down when you're done, or set
-> `calm.mcp.enabled=false` while the server is reachable.
+> or an IP allowlist), tear the tunnel down when you're done, or keep
+> `calm.mcp.enabled=false` (the default) while the server is reachable.
 
 ### Building for Deployment
 

--- a/calm-hub/src/integration-test/java/integration/IntegrationTestProfile.java
+++ b/calm-hub/src/integration-test/java/integration/IntegrationTestProfile.java
@@ -25,7 +25,10 @@ public class IntegrationTestProfile implements QuarkusTestProfile {
     public Map<String, String> getConfigOverrides() {
         // Enable the PUT/upsert paths so the MCP updateArchitecture tool and the
         // equivalent REST PUT endpoint can be exercised by the integration suite.
-        return Map.of("allow.put.operations", "true");
+        return Map.of(
+                "allow.put.operations", "true",
+                "calm.mcp.enabled", "true"
+        );
     }
 }
 

--- a/calm-hub/src/integration-test/java/integration/NitriteIntegrationTestProfile.java
+++ b/calm-hub/src/integration-test/java/integration/NitriteIntegrationTestProfile.java
@@ -25,6 +25,9 @@ public class NitriteIntegrationTestProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Map.of("allow.put.operations", "true");
+        return Map.of(
+                "allow.put.operations", "true",
+                "calm.mcp.enabled", "true"
+        );
     }
 }

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/AdrTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/AdrTools.java
@@ -38,7 +38,7 @@ public class AdrTools {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
 
     @Inject
-    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "true")
+    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "false")
     boolean mcpEnabled;
 
     @Inject

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/ArchitectureTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/ArchitectureTools.java
@@ -30,7 +30,7 @@ public class ArchitectureTools {
     private static final Logger logger = LoggerFactory.getLogger(ArchitectureTools.class);
 
     @Inject
-    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "true")
+    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "false")
     boolean mcpEnabled;
 
     @Inject

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/ControlTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/ControlTools.java
@@ -30,7 +30,7 @@ public class ControlTools {
     private static final Logger logger = LoggerFactory.getLogger(ControlTools.class);
 
     @Inject
-    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "true")
+    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "false")
     boolean mcpEnabled;
 
     @Inject

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/DecoratorTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/DecoratorTools.java
@@ -27,7 +27,7 @@ public class DecoratorTools {
     private static final Logger logger = LoggerFactory.getLogger(DecoratorTools.class);
 
     @Inject
-    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "true")
+    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "false")
     boolean mcpEnabled;
 
     @Inject

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/DomainTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/DomainTools.java
@@ -25,7 +25,7 @@ public class DomainTools {
     private static final Logger logger = LoggerFactory.getLogger(DomainTools.class);
 
     @Inject
-    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "true")
+    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "false")
     boolean mcpEnabled;
 
     @Inject

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/InterfaceTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/InterfaceTools.java
@@ -31,7 +31,7 @@ public class InterfaceTools {
     private static final Logger logger = LoggerFactory.getLogger(InterfaceTools.class);
 
     @Inject
-    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "true")
+    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "false")
     boolean mcpEnabled;
 
     @Inject

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/NamespaceTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/NamespaceTools.java
@@ -25,7 +25,7 @@ public class NamespaceTools {
     private static final Logger logger = LoggerFactory.getLogger(NamespaceTools.class);
 
     @Inject
-    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "true")
+    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "false")
     boolean mcpEnabled;
 
     @Inject

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/PatternTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/PatternTools.java
@@ -30,7 +30,7 @@ public class PatternTools {
     private static final Logger logger = LoggerFactory.getLogger(PatternTools.class);
 
     @Inject
-    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "true")
+    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "false")
     boolean mcpEnabled;
 
     @Inject

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/SearchTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/SearchTools.java
@@ -30,7 +30,7 @@ public class SearchTools {
     private static final int MAX_RESULTS_PER_GROUP = 25;
 
     @Inject
-    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "true")
+    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "false")
     boolean mcpEnabled;
 
     @Inject

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/StandardTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/StandardTools.java
@@ -31,7 +31,7 @@ public class StandardTools {
     private static final Logger logger = LoggerFactory.getLogger(StandardTools.class);
 
     @Inject
-    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "true")
+    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "false")
     boolean mcpEnabled;
 
     @Inject

--- a/calm-hub/src/main/java/org/finos/calm/mcp/tools/TimelineTools.java
+++ b/calm-hub/src/main/java/org/finos/calm/mcp/tools/TimelineTools.java
@@ -30,7 +30,7 @@ public class TimelineTools {
     private static final Logger logger = LoggerFactory.getLogger(TimelineTools.class);
 
     @Inject
-    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "true")
+    @ConfigProperty(name = "calm.mcp.enabled", defaultValue = "false")
     boolean mcpEnabled;
 
     @Inject

--- a/calm-hub/src/main/resources/application.properties
+++ b/calm-hub/src/main/resources/application.properties
@@ -40,10 +40,11 @@ quarkus.http.filter.security.matches=/.*
 quarkus.http.filter.security.methods=GET,POST,PUT,DELETE,PATCH
 quarkus.http.filter.security.header."X-Frame-Options"=DENY
 
-# MCP Server Configuration
-# Enables the embedded Model Context Protocol (MCP) server exposed at /mcp.
-# Defaults to true. Override at runtime with -Dcalm.mcp.enabled=false or the
-# environment variable CALM_MCP_ENABLED=false to disable all MCP tools.
-calm.mcp.enabled=true
+# MCP Server Configuration (experimental)
+# Gates MCP tool invocations. When false (the default), every @Tool method
+# returns a disabled error; the /mcp HTTP endpoint itself remains reachable.
+# Defaults to false. Override at runtime with -Dcalm.mcp.enabled=true or the
+# environment variable CALM_MCP_ENABLED=true to enable all MCP tools.
+calm.mcp.enabled=false
 # Log every JSON-RPC message in dev mode for easier debugging of MCP clients.
 %dev.quarkus.mcp.server.traffic-logging=true

--- a/cli/DEVELOPER_GUIDE.md
+++ b/cli/DEVELOPER_GUIDE.md
@@ -64,7 +64,7 @@ $ npm pack --pack-destination /tmp
 # Note: this will replace an existing calm cli install in the global area
 $ npm install -g /tmp/finos-calm-cli-<version-identifier>.tgz
 
-# run manual verfication of the new version, e.g,.
+# run manual verification of the new version, e.g,.
 #   calm --help
 #   calm init-ai --help
 ```

--- a/cli/src/cli.spec.ts
+++ b/cli/src/cli.spec.ts
@@ -780,6 +780,338 @@ describe('CLI Commands', () => {
         });
     });
 
+    describe('create domain command', () => {
+        beforeEach(async () => {
+            hubCommandsModule = await import('./command-helpers/hub-commands');
+            vi.spyOn(hubCommandsModule, 'runCreateDomain').mockResolvedValue(undefined);
+        });
+
+        it('calls runCreateDomain with name and hub url', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'create', 'domain',
+                '--name', 'risk',
+                '--calm-hub-url', 'http://hub',
+            ]);
+
+            expect(hubCommandsModule.runCreateDomain).toHaveBeenCalledWith(expect.objectContaining({
+                name: 'risk',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
+            }));
+        });
+
+        it('passes --format pretty through to the handler', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'create', 'domain',
+                '--name', 'risk',
+                '--format', 'pretty',
+            ]);
+
+            expect(hubCommandsModule.runCreateDomain).toHaveBeenCalledWith(expect.objectContaining({
+                format: 'pretty',
+            }));
+        });
+    });
+
+    describe('create control-requirement command', () => {
+        beforeEach(async () => {
+            hubCommandsModule = await import('./command-helpers/hub-commands');
+            vi.spyOn(hubCommandsModule, 'runCreateControlRequirement').mockResolvedValue(undefined);
+        });
+
+        it('calls runCreateControlRequirement with domain, name, description and file', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'create', 'control-requirement', 'req.json',
+                '--domain', 'risk',
+                '--name', 'my-control',
+                '--description', 'A control',
+                '--calm-hub-url', 'http://hub',
+            ]);
+
+            expect(hubCommandsModule.runCreateControlRequirement).toHaveBeenCalledWith(expect.objectContaining({
+                domain: 'risk',
+                name: 'my-control',
+                description: 'A control',
+                file: 'req.json',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
+            }));
+        });
+    });
+
+    describe('list domains command', () => {
+        beforeEach(async () => {
+            hubCommandsModule = await import('./command-helpers/hub-commands');
+            vi.spyOn(hubCommandsModule, 'runListDomains').mockResolvedValue(undefined);
+        });
+
+        it('calls runListDomains with hub url', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'list', 'domains',
+                '--calm-hub-url', 'http://hub',
+            ]);
+
+            expect(hubCommandsModule.runListDomains).toHaveBeenCalledWith(expect.objectContaining({
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
+            }));
+        });
+
+        it('passes --format pretty through to the handler', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'list', 'domains',
+                '--format', 'pretty',
+            ]);
+
+            expect(hubCommandsModule.runListDomains).toHaveBeenCalledWith(expect.objectContaining({
+                format: 'pretty',
+            }));
+        });
+    });
+
+    describe('list control-requirements command', () => {
+        beforeEach(async () => {
+            hubCommandsModule = await import('./command-helpers/hub-commands');
+            vi.spyOn(hubCommandsModule, 'runListControlRequirements').mockResolvedValue(undefined);
+        });
+
+        it('calls runListControlRequirements with domain and hub url', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'list', 'control-requirements',
+                '--domain', 'risk',
+                '--calm-hub-url', 'http://hub',
+            ]);
+
+            expect(hubCommandsModule.runListControlRequirements).toHaveBeenCalledWith(expect.objectContaining({
+                domain: 'risk',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
+            }));
+        });
+
+        it('passes --format pretty through to the handler', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'list', 'control-requirements',
+                '--domain', 'risk',
+                '--format', 'pretty',
+            ]);
+
+            expect(hubCommandsModule.runListControlRequirements).toHaveBeenCalledWith(expect.objectContaining({
+                format: 'pretty',
+            }));
+        });
+    });
+
+    describe('push control-requirement command', () => {
+        beforeEach(async () => {
+            hubCommandsModule = await import('./command-helpers/hub-commands');
+            vi.spyOn(hubCommandsModule, 'runPushControlRequirement').mockResolvedValue(undefined);
+        });
+
+        it('calls runPushControlRequirement with domain, controlId, version, metadata and file', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'push', 'control-requirement', 'req.json',
+                '--domain', 'risk',
+                '--control-id', '1',
+                '--ver', '1.0.0',
+                '--name', 'req-name',
+                '--description', 'req-description',
+                '--calm-hub-url', 'http://hub',
+            ]);
+
+            expect(hubCommandsModule.runPushControlRequirement).toHaveBeenCalledWith(expect.objectContaining({
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                name: 'req-name',
+                description: 'req-description',
+                file: 'req.json',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
+            }));
+        });
+
+        it('calls runPushControlRequirement when name and description are omitted', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'push', 'control-requirement', 'req.json',
+                '--domain', 'risk',
+                '--control-id', '1',
+                '--ver', '1.0.0',
+                '--calm-hub-url', 'http://hub',
+            ]);
+
+            expect(hubCommandsModule.runPushControlRequirement).toHaveBeenCalledWith(expect.objectContaining({
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                name: undefined,
+                description: undefined,
+                file: 'req.json',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
+            }));
+        });
+    });
+
+    describe('pull control-requirement command', () => {
+        beforeEach(async () => {
+            hubCommandsModule = await import('./command-helpers/hub-commands');
+            vi.spyOn(hubCommandsModule, 'runPullControlRequirement').mockResolvedValue(undefined);
+        });
+
+        it('calls runPullControlRequirement with domain, controlId and version', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'pull', 'control-requirement',
+                '--domain', 'risk',
+                '--control-id', '1',
+                '--ver', '1.0.0',
+                '--calm-hub-url', 'http://hub',
+            ]);
+
+            expect(hubCommandsModule.runPullControlRequirement).toHaveBeenCalledWith(expect.objectContaining({
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
+            }));
+        });
+
+        it('passes --output through to the handler', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'pull', 'control-requirement',
+                '--domain', 'risk',
+                '--control-id', '1',
+                '--ver', '1.0.0',
+                '--output', 'out.json',
+            ]);
+
+            expect(hubCommandsModule.runPullControlRequirement).toHaveBeenCalledWith(expect.objectContaining({
+                output: 'out.json',
+            }));
+        });
+    });
+
+    describe('push control-configuration command', () => {
+        beforeEach(async () => {
+            hubCommandsModule = await import('./command-helpers/hub-commands');
+            vi.spyOn(hubCommandsModule, 'runPushControlConfiguration').mockResolvedValue(undefined);
+        });
+
+        it('calls runPushControlConfiguration with domain, controlId, configId, version and file', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'push', 'control-configuration', 'cfg.json',
+                '--domain', 'risk',
+                '--control-id', '1',
+                '--config-id', 'cfg-1',
+                '--ver', '1.0.0',
+                '--calm-hub-url', 'http://hub',
+            ]);
+
+            expect(hubCommandsModule.runPushControlConfiguration).toHaveBeenCalledWith(expect.objectContaining({
+                domain: 'risk',
+                controlId: '1',
+                configId: 'cfg-1',
+                version: '1.0.0',
+                file: 'cfg.json',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
+            }));
+        });
+    });
+
+    describe('pull control-configuration command', () => {
+        beforeEach(async () => {
+            hubCommandsModule = await import('./command-helpers/hub-commands');
+            vi.spyOn(hubCommandsModule, 'runPullControlConfiguration').mockResolvedValue(undefined);
+        });
+
+        it('calls runPullControlConfiguration with domain, controlId, configId and version', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'pull', 'control-configuration',
+                '--domain', 'risk',
+                '--control-id', '1',
+                '--config-id', 'cfg-1',
+                '--ver', '1.0.0',
+                '--calm-hub-url', 'http://hub',
+            ]);
+
+            expect(hubCommandsModule.runPullControlConfiguration).toHaveBeenCalledWith(expect.objectContaining({
+                domain: 'risk',
+                controlId: '1',
+                configId: 'cfg-1',
+                version: '1.0.0',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
+            }));
+        });
+
+        it('passes --output through to the handler', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'pull', 'control-configuration',
+                '--domain', 'risk',
+                '--control-id', '1',
+                '--config-id', 'cfg-1',
+                '--ver', '1.0.0',
+                '--output', 'out.json',
+            ]);
+
+            expect(hubCommandsModule.runPullControlConfiguration).toHaveBeenCalledWith(expect.objectContaining({
+                output: 'out.json',
+            }));
+        });
+    });
+
+    describe('create control-configuration command', () => {
+        beforeEach(async () => {
+            hubCommandsModule = await import('./command-helpers/hub-commands');
+            vi.spyOn(hubCommandsModule, 'runCreateControlConfiguration').mockResolvedValue(undefined);
+        });
+
+        it('calls runCreateControlConfiguration with domain, controlId and file', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'create', 'control-configuration', 'cfg.json',
+                '--domain', 'risk',
+                '--control-id', '1',
+                '--calm-hub-url', 'http://hub',
+            ]);
+
+            expect(hubCommandsModule.runCreateControlConfiguration).toHaveBeenCalledWith(expect.objectContaining({
+                domain: 'risk',
+                controlId: '1',
+                file: 'cfg.json',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
+            }));
+        });
+    });
+
+    describe('list control-configurations command', () => {
+        beforeEach(async () => {
+            hubCommandsModule = await import('./command-helpers/hub-commands');
+            vi.spyOn(hubCommandsModule, 'runListControlConfigurations').mockResolvedValue(undefined);
+        });
+
+        it('calls runListControlConfigurations with domain and controlId', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'list', 'control-configurations',
+                '--domain', 'risk',
+                '--control-id', '1',
+                '--calm-hub-url', 'http://hub',
+            ]);
+
+            expect(hubCommandsModule.runListControlConfigurations).toHaveBeenCalledWith(expect.objectContaining({
+                domain: 'risk',
+                controlId: '1',
+                calmHubOptions: expect.objectContaining({ calmHubUrl: 'http://hub' }),
+            }));
+        });
+
+        it('passes --format pretty through to the handler', async () => {
+            await program.parseAsync([
+                'node', 'cli.js', 'hub', 'list', 'control-configurations',
+                '--domain', 'risk',
+                '--control-id', '1',
+                '--format', 'pretty',
+            ]);
+
+            expect(hubCommandsModule.runListControlConfigurations).toHaveBeenCalledWith(expect.objectContaining({
+                format: 'pretty',
+            }));
+        });
+
+    });
+
 });
 
 describe('parseDocumentLoaderConfig', () => {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -5,7 +5,50 @@ import { promptUserForOptions, loadChoicesFromInput } from './command-helpers/ge
 import * as cliConfig from './cli-config';
 import path from 'path';
 import { select } from '@inquirer/prompts';
-import { CreateNamespaceOptions, ListArchitecturesOptions, ListNamespacesOptions, PullArchitectureOptions, PushArchitectureOptions, runCreateNamespace, runListArchitectures, runListNamespaces, runPullArchitecture, runPushArchitecture } from './command-helpers/hub-commands';
+import {
+    CreateNamespaceOptions,
+    ListArchitecturesOptions,
+    ListNamespacesOptions,
+    ListPatternsOptions,
+    ListStandardsOptions,
+    PullArchitectureOptions,
+    PullPatternOptions,
+    PullStandardOptions,
+    PushArchitectureOptions,
+    PushPatternOptions,
+    PushStandardOptions,
+    runCreateNamespace,
+    runListArchitectures,
+    runListNamespaces,
+    runListPatterns,
+    runListStandards,
+    runPullArchitecture,
+    runPullPattern,
+    runPullStandard,
+    runPushArchitecture,
+    runPushPattern,
+    runPushStandard,
+    CreateDomainOptions,
+    ListDomainsOptions,
+    CreateControlRequirementOptions,
+    ListControlRequirementsOptions,
+    PushControlRequirementOptions,
+    PullControlRequirementOptions,
+    PushControlConfigurationOptions,
+    PullControlConfigurationOptions,
+    runCreateDomain,
+    runListDomains,
+    runCreateControlRequirement,
+    runListControlRequirements,
+    runPushControlRequirement,
+    runPullControlRequirement,
+    runPushControlConfiguration,
+    runPullControlConfiguration,
+    CreateControlConfigurationOptions,
+    ListControlConfigurationsOptions,
+    runCreateControlConfiguration,
+    runListControlConfigurations
+} from './command-helpers/hub-commands';
 
 // Shared options used across multiple commands
 const ARCHITECTURE_OPTION = '-a, --architecture <file>';
@@ -41,6 +84,9 @@ const NAME_OPTION = '--name <name>';
 const DESCRIPTION_OPTION = '--description <description>';
 const ID_OPTION = '--id <id>';
 const HUB_VERSION_OPTION = '--ver <version>'; // --version conflicts with Commander's built-in version flag
+const DOMAIN_OPTION = '--domain <domain>';
+const CONTROL_ID_OPTION = '--control-id <controlId>';
+const CONFIG_ID_OPTION = '--config-id <configId>';
 
 export function setupCLI(program: Command) {
     program
@@ -418,6 +464,100 @@ Example:
             await runPushArchitecture(pushOptions);
         });
 
+    hubPushCmd
+        .command('pattern <pattern-file>')
+        .description('Push a CALM pattern file to CALM Hub')
+        .option(NAME_OPTION, 'Name for the pattern in CALM Hub (required when creating a new pattern)')
+        .option(DESCRIPTION_OPTION, 'Description for the pattern')
+        .option(NAMESPACE_OPTION, 'Target namespace', 'default')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .option(ID_OPTION, 'Existing pattern ID (required when adding a new version)')
+        .option(HUB_VERSION_OPTION, 'Semver version to create (required when --id is provided)')
+        .addOption(hubOutputOption)
+        .action(async (patternFile, options) => {
+            const pushPatternOptions: PushPatternOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                namespace: options.namespace,
+                name: options.name,
+                description: options.description,
+                file: patternFile,
+                id: options.id,
+                version: options.ver,
+                format: options.format
+            };
+            await runPushPattern(pushPatternOptions);
+        });
+
+    hubPushCmd
+        .command('standard <standard-file>')
+        .description('Push a CALM standard file to CALM Hub')
+        .option(NAME_OPTION, 'Name for the standard in CALM Hub (required when creating a new standard)')
+        .option(DESCRIPTION_OPTION, 'Description for the standard')
+        .option(NAMESPACE_OPTION, 'Target namespace', 'default')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .option(ID_OPTION, 'Existing standard ID (required when adding a new version)')
+        .option(HUB_VERSION_OPTION, 'Semver version to create (required when --id is provided)')
+        .addOption(hubOutputOption)
+        .action(async (standardFile, options) => {
+            const pushStandardOptions: PushStandardOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                namespace: options.namespace,
+                name: options.name,
+                description: options.description,
+                file: standardFile,
+                id: options.id,
+                version: options.ver,
+                format: options.format
+            };
+            await runPushStandard(pushStandardOptions);
+        });
+
+    hubPushCmd
+        .command('control-requirement <requirement-file>')
+        .description('Push a control requirement version to CALM Hub')
+        .requiredOption(DOMAIN_OPTION, 'Target domain')
+        .requiredOption(CONTROL_ID_OPTION, 'Control ID')
+        .requiredOption(HUB_VERSION_OPTION, 'Semver version to create')
+        .option(NAME_OPTION, 'Name for the requirement version wrapper')
+        .option(DESCRIPTION_OPTION, 'Description for the requirement version wrapper')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .addOption(hubOutputOption)
+        .action(async (requirementFile, options) => {
+            const pushOptions: PushControlRequirementOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                domain: options.domain,
+                controlId: options.controlId,
+                version: options.ver,
+                name: options.name,
+                description: options.description,
+                file: requirementFile,
+                format: options.format
+            };
+            await runPushControlRequirement(pushOptions);
+        });
+
+    hubPushCmd
+        .command('control-configuration <config-file>')
+        .description('Push a control configuration version to CALM Hub')
+        .requiredOption(DOMAIN_OPTION, 'Target domain')
+        .requiredOption(CONTROL_ID_OPTION, 'Control ID')
+        .requiredOption(CONFIG_ID_OPTION, 'Configuration ID')
+        .requiredOption(HUB_VERSION_OPTION, 'Semver version to create')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .addOption(hubOutputOption)
+        .action(async (configFile, options) => {
+            const pushOptions: PushControlConfigurationOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                domain: options.domain,
+                controlId: options.controlId,
+                configId: options.configId,
+                version: options.ver,
+                file: configFile,
+                format: options.format
+            };
+            await runPushControlConfiguration(pushOptions);
+        });
+
     // hub pull
     const hubPullCmd = hubCmd.command('pull').description('Pull a CALM document from CALM Hub');
 
@@ -438,6 +578,84 @@ Example:
                 output: options.output
             };
             await runPullArchitecture(pullOptions);
+        });
+
+    hubPullCmd
+        .command('pattern')
+        .description('Pull a specific version of a CALM pattern from CALM Hub')
+        .requiredOption(NAMESPACE_OPTION, 'Source namespace')
+        .requiredOption(HUB_VERSION_OPTION, 'Version to retrieve')
+        .requiredOption(ID_OPTION, 'Pattern ID to pull')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .option(OUTPUT_OPTION, 'Write output to this file instead of stdout')
+        .action(async (options) => {
+            const pullPatternOptions: PullPatternOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                namespace: options.namespace,
+                id: options.id,
+                version: options.ver,
+                output: options.output
+            };
+            await runPullPattern(pullPatternOptions);
+        });
+
+    hubPullCmd
+        .command('standard')
+        .description('Pull a specific version of a CALM standard from CALM Hub')
+        .requiredOption(NAMESPACE_OPTION, 'Source namespace')
+        .requiredOption(HUB_VERSION_OPTION, 'Version to retrieve')
+        .requiredOption(ID_OPTION, 'Standard ID to pull')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .option(OUTPUT_OPTION, 'Write output to this file instead of stdout')
+        .action(async (options) => {
+            const pullStandardOptions: PullStandardOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                namespace: options.namespace,
+                id: options.id,
+                version: options.ver,
+                output: options.output
+            };
+            await runPullStandard(pullStandardOptions);
+        });
+
+    hubPullCmd
+        .command('control-requirement')
+        .description('Pull a control requirement version from CALM Hub')
+        .requiredOption(DOMAIN_OPTION, 'Source domain')
+        .requiredOption(CONTROL_ID_OPTION, 'Control ID')
+        .requiredOption(HUB_VERSION_OPTION, 'Version to retrieve')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .option(OUTPUT_OPTION, 'Write output to this file instead of stdout')
+        .action(async (options) => {
+            const pullOptions: PullControlRequirementOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                domain: options.domain,
+                controlId: options.controlId,
+                version: options.ver,
+                output: options.output
+            };
+            await runPullControlRequirement(pullOptions);
+        });
+
+    hubPullCmd
+        .command('control-configuration')
+        .description('Pull a control configuration version from CALM Hub')
+        .requiredOption(DOMAIN_OPTION, 'Source domain')
+        .requiredOption(CONTROL_ID_OPTION, 'Control ID')
+        .requiredOption(CONFIG_ID_OPTION, 'Configuration ID')
+        .requiredOption(HUB_VERSION_OPTION, 'Version to retrieve')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .option(OUTPUT_OPTION, 'Write output to this file instead of stdout')
+        .action(async (options) => {
+            const pullOptions: PullControlConfigurationOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                domain: options.domain,
+                controlId: options.controlId,
+                configId: options.configId,
+                version: options.ver,
+                output: options.output
+            };
+            await runPullControlConfiguration(pullOptions);
         });
 
     // hub list
@@ -471,6 +689,81 @@ Example:
             await runListNamespaces(listOptions);
         });
 
+    hubListCmd
+        .command('patterns')
+        .description('List patterns in a namespace')
+        .option(NAMESPACE_OPTION, 'Target namespace', 'default')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .addOption(hubOutputOption)
+        .action(async (options) => {
+            const listPatternsOptions: ListPatternsOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                namespace: options.namespace,
+                format: options.format
+            };
+            await runListPatterns(listPatternsOptions);
+        });
+
+    hubListCmd
+        .command('standards')
+        .description('List standards in a namespace')
+        .option(NAMESPACE_OPTION, 'Target namespace', 'default')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .addOption(hubOutputOption)
+        .action(async (options) => {
+            const listStandardsOptions: ListStandardsOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                namespace: options.namespace,
+                format: options.format
+            };
+            await runListStandards(listStandardsOptions);
+        });
+
+    hubListCmd
+        .command('domains')
+        .description('List all domains')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .addOption(hubOutputOption)
+        .action(async (options) => {
+            const listOptions: ListDomainsOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                format: options.format
+            };
+            await runListDomains(listOptions);
+        });
+
+    hubListCmd
+        .command('control-requirements')
+        .description('List control requirements with versions in a domain')
+        .requiredOption(DOMAIN_OPTION, 'Target domain')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .addOption(hubOutputOption)
+        .action(async (options) => {
+            const listOptions: ListControlRequirementsOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                domain: options.domain,
+                format: options.format
+            };
+            await runListControlRequirements(listOptions);
+        });
+
+    hubListCmd
+        .command('control-configurations')
+        .description('List configurations and versions for a control')
+        .requiredOption(DOMAIN_OPTION, 'Target domain')
+        .requiredOption(CONTROL_ID_OPTION, 'Control ID')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .addOption(hubOutputOption)
+        .action(async (options) => {
+            const listOptions: ListControlConfigurationsOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                domain: options.domain,
+                controlId: options.controlId,
+                format: options.format
+            };
+            await runListControlConfigurations(listOptions);
+        });
+
     // hub create
     const hubCreateCmd = hubCmd.command('create').description('Create CALM Hub resources');
 
@@ -489,6 +782,59 @@ Example:
                 format: options.format
             };
             await runCreateNamespace(createOptions);
+        });
+
+    hubCreateCmd
+        .command('domain')
+        .description('Create a new domain in CALM Hub')
+        .requiredOption(NAME_OPTION, 'Domain name')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .addOption(hubOutputOption)
+        .action(async (options) => {
+            const createOptions: CreateDomainOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                name: options.name,
+                format: options.format
+            };
+            await runCreateDomain(createOptions);
+        });
+
+    hubCreateCmd
+        .command('control-requirement <control-file>')
+        .description('Create a new control in CALM Hub')
+        .requiredOption(DOMAIN_OPTION, 'Target domain')
+        .requiredOption(NAME_OPTION, 'Control name')
+        .requiredOption(DESCRIPTION_OPTION, 'Control description')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .addOption(hubOutputOption)
+        .action(async (controlFile, options) => {
+            const createOptions: CreateControlRequirementOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                domain: options.domain,
+                name: options.name,
+                description: options.description,
+                file: controlFile,
+                format: options.format
+            };
+            await runCreateControlRequirement(createOptions);
+        });
+
+    hubCreateCmd
+        .command('control-configuration <config-file>')
+        .description('Create a new configuration for a control in CALM Hub')
+        .requiredOption(DOMAIN_OPTION, 'Target domain')
+        .requiredOption(CONTROL_ID_OPTION, 'Control ID')
+        .option(CALMHUB_URL_OPTION, 'URL to CALMHub instance')
+        .addOption(hubOutputOption)
+        .action(async (configFile, options) => {
+            const createOptions: CreateControlConfigurationOptions = {
+                calmHubOptions: { calmHubUrl: options.calmHubUrl },
+                domain: options.domain,
+                controlId: options.controlId,
+                file: configFile,
+                format: options.format
+            };
+            await runCreateControlConfiguration(createOptions);
         });
 
     program.addCommand(hubCmd);

--- a/cli/src/command-helpers/hub-commands.spec.ts
+++ b/cli/src/command-helpers/hub-commands.spec.ts
@@ -4,7 +4,11 @@ import * as cliConfig from '../cli-config';
 import * as hubOutput from './hub-output';
 import { runCreateNamespace, runListArchitectures, runListNamespaces, 
     runPullArchitecture, runPushArchitecture,  printPushResult, pushVersioned, 
-    resolveCalmHubOptions, resolveVersionedMetadata  } from './hub-commands';
+    resolveCalmHubOptions, resolveVersionedMetadata,
+    runCreateDomain, runListDomains, runCreateControlRequirement, runListControlRequirements,
+    runPushControlRequirement, runPullControlRequirement, runPushControlConfiguration, runPullControlConfiguration,
+    printIdCreateResult,
+    runCreateControlConfiguration, runListControlConfigurations } from './hub-commands';
 
 // We stub the entire @finos/calm-shared module so no real HTTP is made
 vi.mock('@finos/calm-shared', () => {
@@ -14,7 +18,28 @@ vi.mock('@finos/calm-shared', () => {
         pushArchitecture: vi.fn(),
         pushArchitectureVersion: vi.fn(),
         listArchitectures: vi.fn(),
-        pullArchitecture: vi.fn()
+        pullArchitecture: vi.fn(),
+        pushPattern: vi.fn(),
+        pushPatternVersion: vi.fn(),
+        listPatterns: vi.fn(),
+        pullPattern: vi.fn(),
+        pushStandard: vi.fn(),
+        pushStandardVersion: vi.fn(),
+        listStandards: vi.fn(),
+        pullStandard: vi.fn(),
+        createDomain: vi.fn(),
+        listDomains: vi.fn(),
+        createControl: vi.fn(),
+        listControls: vi.fn(),
+        listControlRequirements: vi.fn(),
+        pushControlRequirement: vi.fn(),
+        pullControlRequirement: vi.fn(),
+        pushControlConfiguration: vi.fn(),
+        pullControlConfiguration: vi.fn(),
+        createControlConfiguration: vi.fn(),
+        listControlConfigurations: vi.fn(),
+        listControlRequirementVersions: vi.fn(),
+        listControlConfigurationVersions: vi.fn()
     };
     return {
         CalmHubClient: vi.fn(() => mockClient),
@@ -606,4 +631,1465 @@ describe('hub-commands', () => {
             expect(result).toEqual({ id: 5, version: '2.0.0', location: '/calm/namespaces/finos/architectures/5/versions/2.0.0' });
         });
     });
+
+    // ── runPushPattern ─────────────────────────────────────────────────────
+
+    describe('runPushPattern', () => {
+        it('calls pushPattern and prints JSON result', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.pushPattern).mockResolvedValue({
+                id: 10, version: '1.0.0', location: '/calm/namespaces/finos/patterns/10/versions/1.0.0'
+            });
+
+            const { runPushPattern } = await import('./hub-commands');
+            await runPushPattern({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-pattern',
+                description: 'desc',
+                file: 'pattern.json'
+            });
+
+            expect(mockClient.pushPattern).toHaveBeenCalledWith('finos', 'my-pattern', 'desc', expect.any(String));
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith(expect.objectContaining({ id: 10, version: '1.0.0' }));
+        });
+
+        it('calls pushPatternVersion when --id is provided', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.pushPatternVersion).mockResolvedValue({
+                id: 10, version: '2.0.0', location: '/calm/namespaces/finos/patterns/10/versions/2.0.0'
+            });
+
+            const { runPushPattern } = await import('./hub-commands');
+            await runPushPattern({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-pattern',
+                description: 'desc',
+                file: 'pattern.json',
+                id: '10',
+                version: '2.0.0'
+            });
+
+            expect(mockClient.pushPatternVersion).toHaveBeenCalledWith('finos', 10, '2.0.0', 'my-pattern', 'desc', expect.any(String));
+        });
+
+        it('auto-fetches name and description from Hub when --id provided and they are omitted', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listPatterns).mockResolvedValue([
+                { id: 10, name: 'fetched-pattern', description: 'fetched-desc', versions: ['1.0.0'] }
+            ]);
+            vi.mocked(mockClient.pushPatternVersion).mockResolvedValue({
+                id: 10, version: '2.0.0', location: '/calm/namespaces/finos/patterns/10/versions/2.0.0'
+            });
+
+            const { runPushPattern } = await import('./hub-commands');
+            await runPushPattern({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                file: 'pattern.json',
+                id: '10',
+                version: '2.0.0'
+            });
+
+            expect(mockClient.listPatterns).toHaveBeenCalledWith('finos');
+            expect(mockClient.pushPatternVersion).toHaveBeenCalledWith('finos', 10, '2.0.0', 'fetched-pattern', 'fetched-desc', expect.any(String));
+        });
+
+        it('exits with error when --name is missing for new pattern', async () => {
+            const { runPushPattern } = await import('./hub-commands');
+            await expect(runPushPattern({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                file: 'pattern.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0, '--name is required when creating a new pattern', 'push pattern', 'json'
+            );
+        });
+
+        it('exits with error when --description is missing for new pattern', async () => {
+            const { runPushPattern } = await import('./hub-commands');
+            await expect(runPushPattern({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-pattern',
+                file: 'pattern.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0, '--description is required when creating a new pattern', 'push pattern', 'json'
+            );
+        });
+
+        it('exits with error when --ver is missing with --id', async () => {
+            const { runPushPattern } = await import('./hub-commands');
+            await expect(runPushPattern({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-pattern',
+                description: 'desc',
+                file: 'pattern.json',
+                id: '10'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0, '--ver is required when --id is provided', 'push pattern', 'json'
+            );
+        });
+
+        it('exits when file cannot be read', async () => {
+            vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'));
+            const { runPushPattern } = await import('./hub-commands');
+            await expect(runPushPattern({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-pattern',
+                description: 'desc',
+                file: 'missing.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalled();
+        });
+
+        it('exits when file is not valid JSON', async () => {
+            vi.mocked(fs.readFile).mockResolvedValue('not json' as unknown as Uint8Array);
+            const { runPushPattern } = await import('./hub-commands');
+            await expect(runPushPattern({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-pattern',
+                description: 'desc',
+                file: 'bad.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalled();
+        });
+
+        it('exits on HubClientError', async () => {
+            const { mockClient, shared } = await getSharedMocks();
+            vi.mocked(mockClient.pushPattern).mockRejectedValue(
+                new shared.HubClientError(409, 'Pattern already exists', 'POST /calm/namespaces/finos/patterns')
+            );
+
+            const { runPushPattern } = await import('./hub-commands');
+            await expect(runPushPattern({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-pattern',
+                description: 'desc',
+                file: 'pattern.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(409, 'Pattern already exists', expect.any(String), 'json');
+        });
+    });
+
+    // ── runPullPattern ─────────────────────────────────────────────────────
+
+    describe('runPullPattern', () => {
+        it('prints JSON to stdout by default', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.pullPattern).mockResolvedValue({ id: 10, patternJson: '{}' });
+            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+            const { runPullPattern } = await import('./hub-commands');
+            await runPullPattern({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', id: '10', version: '1.0.0' });
+
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('"id": 10'));
+            consoleSpy.mockRestore();
+        });
+
+        it('writes to file when --output is provided', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.pullPattern).mockResolvedValue({ id: 10 });
+
+            const { runPullPattern } = await import('./hub-commands');
+            await runPullPattern({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', id: '10', version: '1.0.0', output: 'out.json' });
+
+            expect(fs.writeFile).toHaveBeenCalledWith('out.json', expect.any(String), 'utf-8');
+        });
+
+        it('exits with error when --id is not a valid integer', async () => {
+            const { runPullPattern } = await import('./hub-commands');
+            await expect(runPullPattern({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', id: 'bad', version: '1.0.0' }))
+                .rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0, '--id must be a valid integer', 'pull pattern', 'json'
+            );
+        });
+
+        it('exits on HubClientError', async () => {
+            const { mockClient, shared } = await getSharedMocks();
+            vi.mocked(mockClient.pullPattern).mockRejectedValue(
+                new shared.HubClientError(404, 'Pattern not found', 'GET /calm/namespaces/finos/patterns/99/versions/1.0.0')
+            );
+
+            const { runPullPattern } = await import('./hub-commands');
+            await expect(runPullPattern({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', id: '99', version: '1.0.0' }))
+                .rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(404, 'Pattern not found', expect.any(String), 'json');
+        });
+    });
+
+    // ── runListPatterns ────────────────────────────────────────────────────
+
+    describe('runListPatterns', () => {
+        it('prints JSON array of patterns', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listPatterns).mockResolvedValue([
+                { id: 1, name: 'pattern-a', versions: ['1.0.0'] }
+            ]);
+
+            const { runListPatterns } = await import('./hub-commands');
+            await runListPatterns({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos' });
+
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith([{ id: 1, name: 'pattern-a', versions: ['1.0.0'] }]);
+        });
+
+        it('renders table with ID, NAME, VERSIONS when format is pretty', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listPatterns).mockResolvedValue([
+                { id: 1, name: 'pattern-a', versions: ['1.0.0', '2.0.0'] }
+            ]);
+
+            const { runListPatterns } = await import('./hub-commands');
+            await runListPatterns({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', format: 'pretty' });
+
+            expect(hubOutput.printTableSuccess).toHaveBeenCalledWith(
+                [{ ID: 1, NAME: 'pattern-a', VERSIONS: '1.0.0, 2.0.0' }],
+                [
+                    { key: 'ID', header: 'ID' },
+                    { key: 'NAME', header: 'NAME' },
+                    { key: 'VERSIONS', header: 'VERSIONS' }
+                ]
+            );
+        });
+
+        it('exits when no hub URL is available', async () => {
+            const { runListPatterns } = await import('./hub-commands');
+            await expect(runListPatterns({ calmHubOptions: {}, namespace: 'finos' })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalled();
+        });
+    });
+
+    // ── runPushStandard ────────────────────────────────────────────────────
+
+    describe('runPushStandard', () => {
+        it('calls pushStandard and prints JSON result', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.pushStandard).mockResolvedValue({
+                id: 20, version: '1.0.0', location: '/calm/namespaces/finos/standards/20/versions/1.0.0'
+            });
+
+            const { runPushStandard } = await import('./hub-commands');
+            await runPushStandard({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-standard',
+                description: 'desc',
+                file: 'standard.txt'
+            });
+
+            expect(mockClient.pushStandard).toHaveBeenCalledWith('finos', 'my-standard', 'desc', expect.any(String));
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith(expect.objectContaining({ id: 20, version: '1.0.0' }));
+        });
+
+        it('exits when the standard file is not valid JSON', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(fs.readFile).mockResolvedValue('not valid json content' as unknown as Uint8Array);
+
+            const { runPushStandard } = await import('./hub-commands');
+            await expect(runPushStandard({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-standard',
+                description: 'desc',
+                file: 'standard.txt'
+            })).rejects.toThrow('process.exit');
+
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0, 'File is not valid JSON: standard.txt', 'push standard standard.txt', 'json'
+            );
+            expect(mockClient.pushStandard).not.toHaveBeenCalled();
+        });
+
+        it('calls pushStandardVersion when --id is provided', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.pushStandardVersion).mockResolvedValue({
+                id: 20, version: '2.0.0', location: '/calm/namespaces/finos/standards/20/versions/2.0.0'
+            });
+
+            const { runPushStandard } = await import('./hub-commands');
+            await runPushStandard({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-standard',
+                description: 'desc',
+                file: 'standard.txt',
+                id: '20',
+                version: '2.0.0'
+            });
+
+            expect(mockClient.pushStandardVersion).toHaveBeenCalledWith('finos', 20, '2.0.0', 'my-standard', 'desc', expect.any(String));
+        });
+
+        it('auto-fetches name and description from Hub when --id provided and they are omitted', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listStandards).mockResolvedValue([
+                { id: 20, name: 'fetched-standard', description: 'fetched-desc', versions: ['1.0.0'] }
+            ]);
+            vi.mocked(mockClient.pushStandardVersion).mockResolvedValue({
+                id: 20, version: '2.0.0', location: '/calm/namespaces/finos/standards/20/versions/2.0.0'
+            });
+
+            const { runPushStandard } = await import('./hub-commands');
+            await runPushStandard({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                file: 'standard.txt',
+                id: '20',
+                version: '2.0.0'
+            });
+
+            expect(mockClient.listStandards).toHaveBeenCalledWith('finos');
+            expect(mockClient.pushStandardVersion).toHaveBeenCalledWith('finos', 20, '2.0.0', 'fetched-standard', 'fetched-desc', expect.any(String));
+        });
+
+        it('exits with error when --name is missing for new standard', async () => {
+            const { runPushStandard } = await import('./hub-commands');
+            await expect(runPushStandard({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                file: 'standard.txt'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0, '--name is required when creating a new standard', 'push standard', 'json'
+            );
+        });
+
+        it('exits with error when --description is missing for new standard', async () => {
+            const { runPushStandard } = await import('./hub-commands');
+            await expect(runPushStandard({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-standard',
+                file: 'standard.txt'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0, '--description is required when creating a new standard', 'push standard', 'json'
+            );
+        });
+
+        it('exits with error when --ver is missing with --id', async () => {
+            const { runPushStandard } = await import('./hub-commands');
+            await expect(runPushStandard({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-standard',
+                description: 'desc',
+                file: 'standard.txt',
+                id: '20'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0, '--ver is required when --id is provided', 'push standard', 'json'
+            );
+        });
+
+        it('exits when file cannot be read', async () => {
+            vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'));
+            const { runPushStandard } = await import('./hub-commands');
+            await expect(runPushStandard({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-standard',
+                description: 'desc',
+                file: 'missing.txt'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalled();
+        });
+
+        it('exits on HubClientError', async () => {
+            const { mockClient, shared } = await getSharedMocks();
+            vi.mocked(mockClient.pushStandard).mockRejectedValue(
+                new shared.HubClientError(409, 'Standard already exists', 'POST /calm/namespaces/finos/standards')
+            );
+
+            const { runPushStandard } = await import('./hub-commands');
+            await expect(runPushStandard({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                namespace: 'finos',
+                name: 'my-standard',
+                description: 'desc',
+                file: 'standard.txt'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(409, 'Standard already exists', expect.any(String), 'json');
+        });
+    });
+
+    // ── runPullStandard ────────────────────────────────────────────────────
+
+    describe('runPullStandard', () => {
+        it('prints JSON to stdout by default', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.pullStandard).mockResolvedValue({ id: 20, standardJson: 'raw' });
+            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+            const { runPullStandard } = await import('./hub-commands');
+            await runPullStandard({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', id: '20', version: '1.0.0' });
+
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('"id": 20'));
+            consoleSpy.mockRestore();
+        });
+
+        it('writes to file when --output is provided', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.pullStandard).mockResolvedValue({ id: 20 });
+
+            const { runPullStandard } = await import('./hub-commands');
+            await runPullStandard({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', id: '20', version: '1.0.0', output: 'out.txt' });
+
+            expect(fs.writeFile).toHaveBeenCalledWith('out.txt', expect.any(String), 'utf-8');
+        });
+
+        it('exits with error when --id is not a valid integer', async () => {
+            const { runPullStandard } = await import('./hub-commands');
+            await expect(runPullStandard({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', id: 'bad', version: '1.0.0' }))
+                .rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0, '--id must be a valid integer', 'pull standard', 'json'
+            );
+        });
+
+        it('exits on HubClientError', async () => {
+            const { mockClient, shared } = await getSharedMocks();
+            vi.mocked(mockClient.pullStandard).mockRejectedValue(
+                new shared.HubClientError(404, 'Standard not found', 'GET /calm/namespaces/finos/standards/99/versions/1.0.0')
+            );
+
+            const { runPullStandard } = await import('./hub-commands');
+            await expect(runPullStandard({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', id: '99', version: '1.0.0' }))
+                .rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(404, 'Standard not found', expect.any(String), 'json');
+        });
+    });
+
+    // ── runListStandards ───────────────────────────────────────────────────
+
+    describe('runListStandards', () => {
+        it('prints JSON array of standards', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listStandards).mockResolvedValue([
+                { id: 1, name: 'standard-a', description: 'desc-a', versions: ['1.0.0'] }
+            ]);
+
+            const { runListStandards } = await import('./hub-commands');
+            await runListStandards({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos' });
+
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith([{ id: 1, name: 'standard-a', description: 'desc-a', versions: ['1.0.0'] }]);
+        });
+
+        it('renders table with ID, NAME, DESCRIPTION, VERSIONS when format is pretty', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listStandards).mockResolvedValue([
+                { id: 1, name: 'standard-a', description: 'desc-a', versions: ['1.0.0'] }
+            ]);
+
+            const { runListStandards } = await import('./hub-commands');
+            await runListStandards({ calmHubOptions: { calmHubUrl: 'http://hub' }, namespace: 'finos', format: 'pretty' });
+
+            expect(hubOutput.printTableSuccess).toHaveBeenCalledWith(
+                [{ ID: 1, NAME: 'standard-a', DESCRIPTION: 'desc-a', VERSIONS: '1.0.0' }],
+                [
+                    { key: 'ID', header: 'ID' },
+                    { key: 'NAME', header: 'NAME' },
+                    { key: 'DESCRIPTION', header: 'DESCRIPTION' },
+                    { key: 'VERSIONS', header: 'VERSIONS' }
+                ]
+            );
+        });
+
+        it('exits when no hub URL is available', async () => {
+            const { runListStandards } = await import('./hub-commands');
+            await expect(runListStandards({ calmHubOptions: {}, namespace: 'finos' })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalled();
+        });
+    });
+
+    // ── printIdCreateResult ────────────────────────────────────────────────
+
+    describe('printIdCreateResult', () => {
+        it('calls printTableSuccess with STATUS/ID/LOCATION when format is pretty', () => {
+            printIdCreateResult({ id: 7, location: '/calm/domains/7' }, 'pretty');
+
+            expect(hubOutput.printTableSuccess).toHaveBeenCalledWith(
+                [{ STATUS: 'Created', ID: 7, LOCATION: '/calm/domains/7' }],
+                [
+                    { key: 'STATUS', header: 'STATUS' },
+                    { key: 'ID', header: 'ID' },
+                    { key: 'LOCATION', header: 'LOCATION' }
+                ]
+            );
+        });
+
+        it('calls printJsonSuccess with id and location when format is json', () => {
+            printIdCreateResult({ id: 7, location: '/calm/domains/7' }, 'json');
+
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith({ id: 7, location: '/calm/domains/7' });
+            expect(hubOutput.printTableSuccess).not.toHaveBeenCalled();
+        });
+    });
+
+    // ── runCreateDomain ────────────────────────────────────────────────────
+
+    describe('runCreateDomain', () => {
+        it('calls createDomain and prints JSON result', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.createDomain).mockResolvedValue({ name: 'risk', location: '/calm/domains/risk' });
+
+            await runCreateDomain({ calmHubOptions: { calmHubUrl: 'http://hub' }, name: 'risk' });
+
+            expect(mockClient.createDomain).toHaveBeenCalledWith('risk');
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith({ name: 'risk', location: '/calm/domains/risk' });
+        });
+
+        it('renders table when format is pretty', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.createDomain).mockResolvedValue({ name: 'risk', location: '/calm/domains/risk' });
+
+            await runCreateDomain({ calmHubOptions: { calmHubUrl: 'http://hub' }, name: 'risk', format: 'pretty' });
+
+            expect(hubOutput.printTableSuccess).toHaveBeenCalled();
+        });
+
+        it('exits on 409 conflict', async () => {
+            const { mockClient, shared } = await getSharedMocks();
+            vi.mocked(mockClient.createDomain).mockRejectedValue(
+                new shared.HubClientError(409, 'Domain already exists', 'POST /calm/domains')
+            );
+
+            await expect(runCreateDomain({ calmHubOptions: { calmHubUrl: 'http://hub' }, name: 'risk' }))
+                .rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(409, 'Domain already exists', expect.any(String), 'json');
+        });
+
+        it('exits when no hub URL is available', async () => {
+            await expect(runCreateDomain({ calmHubOptions: {}, name: 'risk' })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalled();
+        });
+    });
+
+    // ── runListDomains ─────────────────────────────────────────────────────
+
+    describe('runListDomains', () => {
+        it('prints JSON list of domains', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listDomains).mockResolvedValue([{ name: 'risk' }, { name: 'compliance' }]);
+
+            await runListDomains({ calmHubOptions: { calmHubUrl: 'http://hub' } });
+
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith([{ name: 'risk' }, { name: 'compliance' }]);
+        });
+
+        it('renders table when format is pretty', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listDomains).mockResolvedValue([{ name: 'risk' }]);
+
+            await runListDomains({ calmHubOptions: { calmHubUrl: 'http://hub' }, format: 'pretty' });
+
+            expect(hubOutput.printTableSuccess).toHaveBeenCalledWith(
+                [{ NAME: 'risk' }],
+                [{ key: 'NAME', header: 'NAME' }]
+            );
+        });
+
+        it('exits when no hub URL is available', async () => {
+            await expect(runListDomains({ calmHubOptions: {} })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalled();
+        });
+    });
+
+    // ── runCreateControlRequirement ────────────────────────────────────────
+
+    describe('runCreateControlRequirement', () => {
+        it('calls createControl and prints JSON result', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.createControl).mockResolvedValue({ id: 42, location: '/calm/domains/risk/controls/42' });
+
+            await runCreateControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                name: 'my-control',
+                description: 'A control',
+                file: 'req.json'
+            });
+
+            expect(mockClient.createControl).toHaveBeenCalledWith('risk', 'my-control', 'A control', expect.any(String));
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith({ id: 42, location: '/calm/domains/risk/controls/42' });
+        });
+
+        it('renders table when format is pretty', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.createControl).mockResolvedValue({ id: 42, location: '/calm/domains/risk/controls/42' });
+
+            await runCreateControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                name: 'my-control',
+                description: 'A control',
+                file: 'req.json',
+                format: 'pretty'
+            });
+
+            expect(hubOutput.printTableSuccess).toHaveBeenCalled();
+        });
+
+        it('exits when name is blank', async () => {
+            await expect(runCreateControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                name: '   ',
+                description: 'A control',
+                file: 'req.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0, '--name is required and must not be blank', 'unknown', 'json'
+            );
+        });
+
+        it('exits when description is blank', async () => {
+            await expect(runCreateControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                name: 'my-control',
+                description: '   ',
+                file: 'req.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0, '--description is required and must not be blank', 'unknown', 'json'
+            );
+        });
+
+        it('exits when file cannot be read', async () => {
+            vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('ENOENT'));
+
+            await expect(runCreateControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                name: 'my-control',
+                description: 'A control',
+                file: 'missing.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, expect.stringContaining('Could not read file'), expect.any(String), 'json');
+        });
+
+        it('exits when file is not valid JSON', async () => {
+            vi.mocked(fs.readFile).mockResolvedValueOnce('not-json' as unknown as Uint8Array);
+
+            await expect(runCreateControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                name: 'my-control',
+                description: 'A control',
+                file: 'bad.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, expect.stringContaining('not valid JSON'), expect.any(String), 'json');
+        });
+
+        it('exits on 409 conflict', async () => {
+            const { mockClient, shared } = await getSharedMocks();
+            vi.mocked(mockClient.createControl).mockRejectedValue(
+                new shared.HubClientError(409, 'Control already exists', 'POST /calm/domains/risk/controls')
+            );
+
+            await expect(runCreateControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                name: 'my-control',
+                description: 'A control',
+                file: 'req.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(409, 'Control already exists', expect.any(String), 'json');
+        });
+    });
+
+    // ── runListControlRequirements ─────────────────────────────────────────
+
+    describe('runListControlRequirements', () => {
+        it('prints JSON list of control requirements with versions', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControlRequirements).mockResolvedValue([
+                {
+                    'control-id': 20,
+                    name: 'Encryption At Rest Requirement Updated',
+                    description: 'Updated control for encryption at rest',
+                    versions: ['1.0.0']
+                }
+            ]);
+
+            await runListControlRequirements({ calmHubOptions: { calmHubUrl: 'http://hub' }, domain: 'risk' });
+
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith([
+                {
+                    'control-id': 20,
+                    name: 'Encryption At Rest Requirement Updated',
+                    description: 'Updated control for encryption at rest',
+                    versions: ['1.0.0']
+                }
+            ]);
+        });
+
+        it('renders table when format is pretty', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControlRequirements).mockResolvedValue([
+                {
+                    'control-id': 21,
+                    name: 'Data Retention Requirement',
+                    description: 'Control for data retention',
+                    versions: ['1.0.0', '2.0.0']
+                }
+            ]);
+
+            await runListControlRequirements({ calmHubOptions: { calmHubUrl: 'http://hub' }, domain: 'risk', format: 'pretty' });
+
+            expect(hubOutput.printTableSuccess).toHaveBeenCalledWith(
+                [{
+                    'CONTROL-ID': 21,
+                    NAME: 'Data Retention Requirement',
+                    DESCRIPTION: 'Control for data retention',
+                    VERSIONS: '1.0.0, 2.0.0'
+                }],
+                [
+                    { key: 'CONTROL-ID', header: 'CONTROL-ID' },
+                    { key: 'NAME', header: 'NAME' },
+                    { key: 'DESCRIPTION', header: 'DESCRIPTION' },
+                    { key: 'VERSIONS', header: 'VERSIONS' }
+                ]
+            );
+        });
+
+        it('renders blank description when not provided', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControlRequirements).mockResolvedValue([
+                { 'control-id': 1, name: 'control-a', versions: ['1.0.0'] }
+            ]);
+
+            await runListControlRequirements({ calmHubOptions: { calmHubUrl: 'http://hub' }, domain: 'risk', format: 'pretty' });
+
+            expect(hubOutput.printTableSuccess).toHaveBeenCalledWith(
+                [{ 'CONTROL-ID': 1, NAME: 'control-a', DESCRIPTION: '', VERSIONS: '1.0.0' }],
+                [
+                    { key: 'CONTROL-ID', header: 'CONTROL-ID' },
+                    { key: 'NAME', header: 'NAME' },
+                    { key: 'DESCRIPTION', header: 'DESCRIPTION' },
+                    { key: 'VERSIONS', header: 'VERSIONS' }
+                ]
+            );
+        });
+
+        it('exits when no hub URL is available', async () => {
+            await expect(runListControlRequirements({ calmHubOptions: {}, domain: 'risk' })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalled();
+        });
+    });
+
+    // ── runPushControlRequirement ──────────────────────────────────────────
+
+    describe('runPushControlRequirement', () => {
+        it('calls pushControlRequirement and prints result', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.pushControlRequirement).mockResolvedValue({
+                id: 1, version: '1.0.0', location: '/calm/domains/risk/controls/1/requirement/versions/1.0.0'
+            });
+
+            await runPushControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                name: 'req-name',
+                description: 'req-description',
+                file: 'req.json'
+            });
+
+            expect(mockClient.pushControlRequirement).toHaveBeenCalledWith('risk', 1, '1.0.0', 'req-name', 'req-description', expect.any(String));
+            expect(mockClient.listControls).not.toHaveBeenCalled();
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith(expect.objectContaining({ id: 1, version: '1.0.0' }));
+        });
+
+        it('uses listControls fallback when name and description are omitted', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControls).mockResolvedValue([{ id: 1, name: 'fallback-name', description: 'fallback-description' }]);
+            vi.mocked(mockClient.pushControlRequirement).mockResolvedValue({
+                id: 1, version: '1.0.0', location: '/calm/domains/risk/controls/1/requirement/versions/1.0.0'
+            });
+
+            await runPushControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                file: 'req.json'
+            });
+
+            expect(mockClient.listControls).toHaveBeenCalledWith('risk');
+            expect(mockClient.pushControlRequirement).toHaveBeenCalledWith(
+                'risk',
+                1,
+                '1.0.0',
+                'fallback-name',
+                'fallback-description',
+                expect.any(String)
+            );
+        });
+
+        it('uses fallback only for missing name when description is provided', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControls).mockResolvedValue([{ id: 1, name: 'fallback-name', description: 'fallback-description' }]);
+            vi.mocked(mockClient.pushControlRequirement).mockResolvedValue({
+                id: 1, version: '1.0.0', location: '/calm/domains/risk/controls/1/requirement/versions/1.0.0'
+            });
+
+            await runPushControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                description: 'cli-description',
+                file: 'req.json'
+            });
+
+            expect(mockClient.listControls).toHaveBeenCalledWith('risk');
+            expect(mockClient.pushControlRequirement).toHaveBeenCalledWith(
+                'risk',
+                1,
+                '1.0.0',
+                'fallback-name',
+                'cli-description',
+                expect.any(String)
+            );
+        });
+
+        it('uses fallback only for missing description when name is provided', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControls).mockResolvedValue([{ id: 1, name: 'fallback-name', description: 'fallback-description' }]);
+            vi.mocked(mockClient.pushControlRequirement).mockResolvedValue({
+                id: 1, version: '1.0.0', location: '/calm/domains/risk/controls/1/requirement/versions/1.0.0'
+            });
+
+            await runPushControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                name: 'cli-name',
+                file: 'req.json'
+            });
+
+            expect(mockClient.listControls).toHaveBeenCalledWith('risk');
+            expect(mockClient.pushControlRequirement).toHaveBeenCalledWith(
+                'risk',
+                1,
+                '1.0.0',
+                'cli-name',
+                'fallback-description',
+                expect.any(String)
+            );
+        });
+
+        it('treats empty CLI values as missing and falls back to listControls', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControls).mockResolvedValue([{ id: 1, name: 'fallback-name', description: 'fallback-description' }]);
+            vi.mocked(mockClient.pushControlRequirement).mockResolvedValue({
+                id: 1, version: '1.0.0', location: '/calm/domains/risk/controls/1/requirement/versions/1.0.0'
+            });
+
+            await runPushControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                name: '   ',
+                description: '\t',
+                file: 'req.json'
+            });
+
+            expect(mockClient.listControls).toHaveBeenCalledWith('risk');
+            expect(mockClient.pushControlRequirement).toHaveBeenCalledWith(
+                'risk',
+                1,
+                '1.0.0',
+                'fallback-name',
+                'fallback-description',
+                expect.any(String)
+            );
+        });
+
+        it('exits when control is not found during fallback lookup', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControls).mockResolvedValue([{ id: 2, name: 'other', description: 'other-desc' }]);
+
+            await expect(runPushControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                file: 'req.json'
+            })).rejects.toThrow('process.exit');
+
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0,
+                'Control with id 1 not found in domain risk',
+                expect.any(String),
+                'json'
+            );
+            expect(mockClient.pushControlRequirement).not.toHaveBeenCalled();
+        });
+
+        it('exits when fallback control is missing name', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControls).mockResolvedValue([{ id: 1, name: '', description: 'fallback-description' }]);
+
+            await expect(runPushControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                file: 'req.json'
+            })).rejects.toThrow('process.exit');
+
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0,
+                'Control with id 1 in domain risk is missing name or description',
+                expect.any(String),
+                'json'
+            );
+            expect(mockClient.pushControlRequirement).not.toHaveBeenCalled();
+        });
+
+        it('exits when fallback control is missing description', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControls).mockResolvedValue([{ id: 1, name: 'fallback-name', description: '' }]);
+
+            await expect(runPushControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                file: 'req.json'
+            })).rejects.toThrow('process.exit');
+
+            expect(hubOutput.printError).toHaveBeenCalledWith(
+                0,
+                'Control with id 1 in domain risk is missing name or description',
+                expect.any(String),
+                'json'
+            );
+            expect(mockClient.pushControlRequirement).not.toHaveBeenCalled();
+        });
+
+        it('renders table when format is pretty', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.pushControlRequirement).mockResolvedValue({
+                id: 1, version: '1.0.0', location: '/loc'
+            });
+
+            await runPushControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                name: 'req-name',
+                description: 'req-description',
+                file: 'req.json',
+                format: 'pretty'
+            });
+
+            expect(hubOutput.printTableSuccess).toHaveBeenCalled();
+        });
+
+        it('exits when controlId is not a valid integer', async () => {
+            await expect(runPushControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: 'abc',
+                version: '1.0.0',
+                name: 'req-name',
+                description: 'req-description',
+                file: 'req.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, '--control-id must be a valid integer', expect.any(String), 'json');
+        });
+
+        it('exits when file cannot be read', async () => {
+            vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('ENOENT'));
+
+            await expect(runPushControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                name: 'req-name',
+                description: 'req-description',
+                file: 'missing.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, expect.stringContaining('Could not read file'), expect.any(String), 'json');
+        });
+
+        it('exits on Hub error', async () => {
+            const { mockClient, shared } = await getSharedMocks();
+            vi.mocked(mockClient.pushControlRequirement).mockRejectedValue(
+                new shared.HubClientError(400, 'Bad request', 'POST /calm/domains/risk/controls/1/requirement/versions/1.0.0')
+            );
+
+            await expect(runPushControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                name: 'req-name',
+                description: 'req-description',
+                file: 'req.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(400, 'Bad request', expect.any(String), 'json');
+        });
+    });
+
+    // ── runPullControlRequirement ──────────────────────────────────────────
+
+    describe('runPullControlRequirement', () => {
+        it('writes JSON to stdout', async () => {
+            const { mockClient } = await getSharedMocks();
+            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+            vi.mocked(mockClient.pullControlRequirement).mockResolvedValue({ type: 'control-requirement', requirements: [] });
+
+            await runPullControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0'
+            });
+
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('control-requirement'));
+            consoleSpy.mockRestore();
+        });
+
+        it('writes to file when --output is provided', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.pullControlRequirement).mockResolvedValue({ type: 'control-requirement', requirements: [] });
+
+            await runPullControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                version: '1.0.0',
+                output: 'out.json'
+            });
+
+            expect(fs.writeFile).toHaveBeenCalledWith('out.json', expect.stringContaining('control-requirement'), 'utf-8');
+        });
+
+        it('exits when controlId is not a valid integer', async () => {
+            await expect(runPullControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: 'xyz',
+                version: '1.0.0'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, '--control-id must be a valid integer', expect.any(String), 'json');
+        });
+
+        it('exits on Hub error', async () => {
+            const { mockClient, shared } = await getSharedMocks();
+            vi.mocked(mockClient.pullControlRequirement).mockRejectedValue(
+                new shared.HubClientError(404, 'Not found', 'GET /calm/domains/risk/controls/99/requirement/versions/1.0.0')
+            );
+
+            await expect(runPullControlRequirement({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '99',
+                version: '1.0.0'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(404, 'Not found', expect.any(String), 'json');
+        });
+    });
+
+    // ── runPushControlConfiguration ────────────────────────────────────────
+
+    describe('runPushControlConfiguration', () => {
+        it('calls pushControlConfiguration and prints result', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.pushControlConfiguration).mockResolvedValue({
+                id: 1, version: '1.0.0', location: '/calm/domains/risk/controls/1/configurations/5/versions/1.0.0'
+            });
+
+            await runPushControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                configId: '5',
+                version: '1.0.0',
+                file: 'cfg.json'
+            });
+
+            expect(mockClient.pushControlConfiguration).toHaveBeenCalledWith('risk', 1, 5, '1.0.0', expect.any(String));
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith(expect.objectContaining({ id: 1, version: '1.0.0' }));
+        });
+
+        it('exits when controlId is not a valid integer', async () => {
+            await expect(runPushControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: 'bad',
+                configId: '5',
+                version: '1.0.0',
+                file: 'cfg.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, '--control-id must be a valid integer', expect.any(String), 'json');
+        });
+
+        it('exits when configId is not a valid integer', async () => {
+            await runPushControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                configId: 'cfg-1',
+                version: '1.0.0',
+                file: 'cfg.json'
+            }).catch(() => undefined);
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, '--config-id must be a valid integer', expect.any(String), 'json');
+            expect(exitSpy).toHaveBeenCalledWith(1);
+        });
+
+        it('exits when file cannot be read', async () => {
+            vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('ENOENT'));
+
+            await expect(runPushControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                configId: '5',
+                version: '1.0.0',
+                file: 'missing.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, expect.stringContaining('Could not read file'), expect.any(String), 'json');
+        });
+
+        it('exits when file is not valid JSON', async () => {
+            vi.mocked(fs.readFile).mockResolvedValueOnce('not-json' as unknown as Uint8Array);
+
+            await expect(runPushControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                configId: '5',
+                version: '1.0.0',
+                file: 'bad.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, expect.stringContaining('not valid JSON'), expect.any(String), 'json');
+        });
+
+        it('exits on Hub error', async () => {
+            const { mockClient, shared } = await getSharedMocks();
+            vi.mocked(mockClient.pushControlConfiguration).mockRejectedValue(
+                new shared.HubClientError(400, 'Bad request', 'POST /calm/domains/risk/controls/1/configurations/5/versions/1.0.0')
+            );
+
+            await expect(runPushControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                configId: '5',
+                version: '1.0.0',
+                file: 'cfg.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(400, 'Bad request', expect.any(String), 'json');
+        });
+    });
+
+    // ── runPullControlConfiguration ────────────────────────────────────────
+
+    describe('runPullControlConfiguration', () => {
+        it('writes JSON to stdout', async () => {
+            const { mockClient } = await getSharedMocks();
+            const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+            vi.mocked(mockClient.pullControlConfiguration).mockResolvedValue({ type: 'control-configuration', config: {} });
+
+            await runPullControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                configId: '5',
+                version: '1.0.0'
+            });
+
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('control-configuration'));
+            consoleSpy.mockRestore();
+        });
+
+        it('writes to file when --output is provided', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.pullControlConfiguration).mockResolvedValue({ type: 'control-configuration', config: {} });
+
+            await runPullControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                configId: '5',
+                version: '1.0.0',
+                output: 'out.json'
+            });
+
+            expect(fs.writeFile).toHaveBeenCalledWith('out.json', expect.stringContaining('control-configuration'), 'utf-8');
+        });
+
+        it('exits when controlId is not a valid integer', async () => {
+            await expect(runPullControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: 'xyz',
+                configId: '5',
+                version: '1.0.0'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, '--control-id must be a valid integer', expect.any(String), 'json');
+        });
+
+        it('exits when configId is not a valid integer', async () => {
+            await runPushControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                configId: 'cfg-1',
+                version: '1.0.0',
+                file: 'cfg.json'
+            }).catch(() => undefined);
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, '--config-id must be a valid integer', expect.any(String), 'json');
+            expect(exitSpy).toHaveBeenCalledWith(1);
+        });
+
+        it('exits on Hub error', async () => {
+            const { mockClient, shared } = await getSharedMocks();
+            vi.mocked(mockClient.pullControlConfiguration).mockRejectedValue(
+                new shared.HubClientError(404, 'Not found', 'GET /calm/domains/risk/controls/99/configurations/5/versions/1.0.0')
+            );
+
+            await expect(runPullControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '99',
+                configId: '5',
+                version: '1.0.0'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(404, 'Not found', expect.any(String), 'json');
+        });
+    });
+
+    // ── runCreateControlConfiguration ─────────────────────────────────────────
+
+    describe('runCreateControlConfiguration', () => {
+        it('calls createControlConfiguration and prints JSON result', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.createControlConfiguration).mockResolvedValue({
+                id: 5, location: '/calm/domains/risk/controls/1/configurations/5'
+            });
+
+            await runCreateControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                file: 'cfg.json'
+            });
+
+            expect(mockClient.createControlConfiguration).toHaveBeenCalledWith('risk', 1, expect.any(String));
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith({ id: 5, location: '/calm/domains/risk/controls/1/configurations/5' });
+        });
+
+        it('renders table when format is pretty', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.createControlConfiguration).mockResolvedValue({
+                id: 5, location: '/calm/domains/risk/controls/1/configurations/5'
+            });
+
+            await runCreateControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                file: 'cfg.json',
+                format: 'pretty'
+            });
+
+            expect(hubOutput.printTableSuccess).toHaveBeenCalled();
+        });
+
+        it('exits when controlId is not a valid integer', async () => {
+            await expect(runCreateControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: 'abc',
+                file: 'cfg.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, '--control-id must be a valid integer', expect.any(String), 'json');
+        });
+
+        it('exits when file cannot be read', async () => {
+            vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('ENOENT'));
+
+            await expect(runCreateControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                file: 'missing.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, expect.stringContaining('Could not read file'), expect.any(String), 'json');
+        });
+
+        it('exits on Hub error', async () => {
+            const { mockClient, shared } = await getSharedMocks();
+            vi.mocked(mockClient.createControlConfiguration).mockRejectedValue(
+                new shared.HubClientError(404, 'Control not found', 'POST /calm/domains/risk/controls/99/configurations')
+            );
+
+            await expect(runCreateControlConfiguration({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '99',
+                file: 'cfg.json'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(404, 'Control not found', expect.any(String), 'json');
+        });
+    });
+
+    // ── runListControlConfigurations ──────────────────────────────────────────
+
+    describe('runListControlConfigurations', () => {
+        it('prints JSON list of configurations with versions', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControlConfigurations).mockResolvedValue([1, 2, 3]);
+            vi.mocked(mockClient.listControlConfigurationVersions)
+                .mockResolvedValueOnce(['1.0.0'])
+                .mockResolvedValueOnce(['1.0.0', '2.0.0'])
+                .mockResolvedValueOnce(['3.0.0']);
+
+            await runListControlConfigurations({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1'
+            });
+
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith([
+                { 'config-id': 1, versions: ['1.0.0'] },
+                { 'config-id': 2, versions: ['1.0.0', '2.0.0'] },
+                { 'config-id': 3, versions: ['3.0.0'] }
+            ]);
+        });
+
+        it('renders table when format is pretty', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControlConfigurations).mockResolvedValue([1, 2]);
+            vi.mocked(mockClient.listControlConfigurationVersions)
+                .mockResolvedValueOnce(['1.0.0'])
+                .mockResolvedValueOnce(['1.0.0', '2.0.0']);
+
+            await runListControlConfigurations({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                format: 'pretty'
+            });
+
+            expect(hubOutput.printTableSuccess).toHaveBeenCalledWith(
+                [
+                    { 'CONFIG-ID': 1, VERSIONS: '1.0.0' },
+                    { 'CONFIG-ID': 2, VERSIONS: '1.0.0, 2.0.0' }
+                ],
+                [
+                    { key: 'CONFIG-ID', header: 'CONFIG-ID' },
+                    { key: 'VERSIONS', header: 'VERSIONS' }
+                ]
+            );
+        });
+
+        it('sorts configurations by ID ascending before output', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControlConfigurations).mockResolvedValue([3, 1]);
+            vi.mocked(mockClient.listControlConfigurationVersions)
+                .mockResolvedValueOnce(['1.0.0'])
+                .mockResolvedValueOnce(['3.0.0']);
+
+            await runListControlConfigurations({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1'
+            });
+
+            expect(mockClient.listControlConfigurationVersions).toHaveBeenNthCalledWith(1, 'risk', 1, 1);
+            expect(mockClient.listControlConfigurationVersions).toHaveBeenNthCalledWith(2, 'risk', 1, 3);
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith([
+                { 'config-id': 1, versions: ['1.0.0'] },
+                { 'config-id': 3, versions: ['3.0.0'] }
+            ]);
+        });
+
+        it('prints empty JSON array when there are no configurations', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControlConfigurations).mockResolvedValue([]);
+
+            await runListControlConfigurations({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1'
+            });
+
+            expect(mockClient.listControlConfigurationVersions).not.toHaveBeenCalled();
+            expect(hubOutput.printJsonSuccess).toHaveBeenCalledWith([]);
+        });
+
+        it('includes configurations that have no versions', async () => {
+            const { mockClient } = await getSharedMocks();
+            vi.mocked(mockClient.listControlConfigurations).mockResolvedValue([3]);
+            vi.mocked(mockClient.listControlConfigurationVersions).mockResolvedValueOnce([]);
+
+            await runListControlConfigurations({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1',
+                format: 'pretty'
+            });
+
+            expect(hubOutput.printTableSuccess).toHaveBeenCalledWith(
+                [{ 'CONFIG-ID': 3, VERSIONS: '' }],
+                [
+                    { key: 'CONFIG-ID', header: 'CONFIG-ID' },
+                    { key: 'VERSIONS', header: 'VERSIONS' }
+                ]
+            );
+        });
+
+        it('exits when controlId is not a valid integer', async () => {
+            await expect(runListControlConfigurations({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: 'abc'
+            })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalledWith(0, '--control-id must be a valid integer', expect.any(String), 'json');
+        });
+
+        it('exits when no hub URL is available', async () => {
+            await expect(runListControlConfigurations({ calmHubOptions: {}, domain: 'risk', controlId: '1' })).rejects.toThrow('process.exit');
+            expect(hubOutput.printError).toHaveBeenCalled();
+        });
+
+        it('exits when a version lookup fails', async () => {
+            const { mockClient, shared } = await getSharedMocks();
+            vi.mocked(mockClient.listControlConfigurations).mockResolvedValue([1, 2]);
+            vi.mocked(mockClient.listControlConfigurationVersions)
+                .mockResolvedValueOnce(['1.0.0'])
+                .mockRejectedValueOnce(new shared.HubClientError(404, 'Not found', 'GET /calm/domains/risk/controls/1/configurations/2/versions'));
+
+            await expect(runListControlConfigurations({
+                calmHubOptions: { calmHubUrl: 'http://hub' },
+                domain: 'risk',
+                controlId: '1'
+            })).rejects.toThrow('process.exit');
+
+            expect(hubOutput.printError).toHaveBeenCalledWith(404, 'Not found', expect.any(String), 'json');
+        });
+    });
+
 });

--- a/cli/src/command-helpers/hub-commands.ts
+++ b/cli/src/command-helpers/hub-commands.ts
@@ -1,11 +1,17 @@
 import { readFile, writeFile } from 'fs/promises';
-import { CalmHubClient, CalmHubOptions, HubArchitectureSummary, HubClientError } from '@finos/calm-shared';
+import { CalmHubClient, CalmHubOptions, HubArchitectureSummary, HubClientError, HubPatternSummary, HubStandardSummary, HubDomainSummary, HubControlRequirementSummary, HubDomainCreateResult } from '@finos/calm-shared';
 import { OutputFormat, parseOutputFormat, printError, printJsonSuccess, printTableSuccess } from './hub-output';
 import * as cliConfig from '../cli-config';
 
 // ── Hub URL resolution ────────────────────────────────────────────────────────
 
 class HubCommandError extends Error {
+    /**
+     * Creates a typed command error for user-facing Hub command failures.
+     * @param status HTTP-like status code.
+     * @param error Error message.
+     * @param request Request label.
+     */
     constructor(
         public status: number,
         public error: string,
@@ -61,6 +67,11 @@ export interface PushArchitectureResult {
     location: string;
 }
 
+/**
+ * Prints a push operation result in either pretty table or JSON format.
+ * @param result Push result payload.
+ * @param format Output format selector.
+ */
 export function printPushResult(result: PushArchitectureResult, format: OutputFormat): void {
     if (format === 'pretty') {
         printTableSuccess(
@@ -77,6 +88,16 @@ export function printPushResult(result: PushArchitectureResult, format: OutputFo
     }
 }
 
+/**
+ * Resolves missing architecture name/description from an existing architecture id.
+ * @param client CALM Hub API client.
+ * @param namespace Target namespace.
+ * @param parsedId Architecture id.
+ * @param name Optional name supplied by the user.
+ * @param description Optional description supplied by the user.
+ * @param format Output format used for error handling.
+ * @returns Resolved name and description.
+ */
 export async function resolveVersionedMetadata(
     client: CalmHubClient,
     namespace: string,
@@ -106,6 +127,14 @@ export async function resolveVersionedMetadata(
     };
 }
 
+/**
+ * Pushes a new architecture version for an existing architecture id.
+ * @param client CALM Hub API client.
+ * @param options Command options.
+ * @param fileContent Architecture JSON payload.
+ * @param format Output format used for error handling.
+ * @returns Push result with id, version, and location.
+ */
 export async function pushVersioned(
     client: CalmHubClient,
     options: PushArchitectureOptions,
@@ -142,6 +171,12 @@ export async function pushVersioned(
     );
 }
 
+/**
+ * Resolves CALM Hub options and exits with formatted error output on failure.
+ * @param opts Raw hub options.
+ * @param format Output format used for errors.
+ * @returns Fully-resolved hub options.
+ */
 async function handleOptionsLoadError(opts: CalmHubOptions, format: OutputFormat = 'json'): Promise<CalmHubOptions> {
     try {
         return await resolveCalmHubOptions(opts);
@@ -150,6 +185,10 @@ async function handleOptionsLoadError(opts: CalmHubOptions, format: OutputFormat
     }
 }
 
+/**
+ * Pushes a new architecture or a versioned update to CALM Hub.
+ * @param options Command options.
+ */
 export async function runPushArchitecture(options: PushArchitectureOptions): Promise<void> {
     const format: OutputFormat = parseOutputFormat(options.format);
 
@@ -202,6 +241,10 @@ export interface PullArchitectureOptions {
     output?: string;
 }
 
+/**
+ * Pulls an architecture version from CALM Hub and writes it to stdout or a file.
+ * @param options Command options.
+ */
 export async function runPullArchitecture(options: PullArchitectureOptions): Promise<void> {
     const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions);
     const client = new CalmHubClient(calmHubOptions);
@@ -234,6 +277,10 @@ export interface ListArchitecturesOptions {
     format?: string;
 }
 
+/**
+ * Lists architectures in a namespace.
+ * @param options Command options.
+ */
 export async function runListArchitectures(options: ListArchitecturesOptions): Promise<void> {
     const format: OutputFormat = parseOutputFormat(options.format);
     const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
@@ -268,6 +315,10 @@ export interface CreateNamespaceOptions {
     format?: string;
 }
 
+/**
+ * Creates a new namespace in CALM Hub.
+ * @param options Command options.
+ */
 export async function runCreateNamespace(options: CreateNamespaceOptions): Promise<void> {
     const format: OutputFormat = parseOutputFormat(options.format);
     if (!options.description?.trim()) {
@@ -303,6 +354,10 @@ export interface ListNamespacesOptions {
     format?: string;
 }
 
+/**
+ * Lists all namespaces in CALM Hub.
+ * @param options Command options.
+ */
 export async function runListNamespaces(options: ListNamespacesOptions): Promise<void> {
     const format: OutputFormat = parseOutputFormat(options.format);
     const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
@@ -327,8 +382,977 @@ export async function runListNamespaces(options: ListNamespacesOptions): Promise
     }
 }
 
+// ── push pattern ──────────────────────────────────────────────────────────────
+
+export interface PushPatternOptions {
+    calmHubOptions: CalmHubOptions;
+    namespace: string;
+    name?: string;
+    description?: string;
+    file: string;
+    id?: string;
+    version?: string;
+    format?: string;
+}
+
+/**
+ * Resolves missing pattern name/description from an existing pattern id.
+ * @param client CALM Hub API client.
+ * @param namespace Target namespace.
+ * @param parsedId Pattern id.
+ * @param name Optional name supplied by the user.
+ * @param description Optional description supplied by the user.
+ * @param format Output format used for error handling.
+ * @returns Resolved name and description.
+ */
+export async function resolvePatternMetadata(
+    client: CalmHubClient,
+    namespace: string,
+    parsedId: number,
+    name: string | undefined,
+    description: string | undefined,
+    format: OutputFormat
+): Promise<{ name: string; description: string }> {
+    if (name && description !== undefined) {
+        return { name, description };
+    }
+
+    let patterns: HubPatternSummary[] = [];
+    try {
+        patterns = await client.listPatterns(namespace);
+    } catch (err) {
+        handleHubError(err, format);
+    }
+    const existing = patterns.find(p => p.id === parsedId);
+    if (!existing) {
+        printError(0, `Pattern with id ${parsedId} not found in namespace ${namespace}`, 'push pattern', format);
+        process.exit(1);
+    }
+    return {
+        name: name ?? existing.name,
+        description: description ?? existing.description ?? ''
+    };
+}
+
+/**
+ * Pushes a new pattern version for an existing pattern id.
+ * @param client CALM Hub API client.
+ * @param options Command options.
+ * @param fileContent Pattern JSON payload.
+ * @param format Output format used for error handling.
+ * @returns Push result with id, version, and location.
+ */
+export async function pushPatternVersioned(
+    client: CalmHubClient,
+    options: PushPatternOptions,
+    fileContent: string,
+    format: OutputFormat
+): Promise<PushArchitectureResult> {
+    if (!options.version) {
+        printError(0, '--ver is required when --id is provided', 'push pattern', format);
+        process.exit(1);
+    }
+
+    const parsedId = parseInt(options.id!, 10);
+    if (!Number.isFinite(parsedId)) {
+        printError(0, '--id must be a valid integer', 'push pattern', format);
+        process.exit(1);
+    }
+
+    const { name, description } = await resolvePatternMetadata(
+        client,
+        options.namespace,
+        parsedId,
+        options.name,
+        options.description,
+        format
+    );
+
+    return client.pushPatternVersion(
+        options.namespace,
+        parsedId,
+        options.version,
+        name,
+        description,
+        fileContent
+    );
+}
+
+/**
+ * Pushes a new pattern or a versioned update to CALM Hub.
+ * @param options Command options.
+ */
+export async function runPushPattern(options: PushPatternOptions): Promise<void> {
+    const format: OutputFormat = parseOutputFormat(options.format);
+
+    if (!options.id && !options.name) {
+        printError(0, '--name is required when creating a new pattern', 'push pattern', format);
+        process.exit(1);
+    }
+
+    if (!options.id && !options.description) {
+        printError(0, '--description is required when creating a new pattern', 'push pattern', format);
+        process.exit(1);
+    }
+
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
+
+    let fileContent: string;
+    try {
+        fileContent = await readFile(options.file, 'utf-8');
+    } catch {
+        printError(0, `Could not read file: ${options.file}`, `push pattern ${options.file}`, format);
+        process.exit(1);
+    }
+
+    try {
+        JSON.parse(fileContent);
+    } catch {
+        printError(0, `File is not valid JSON: ${options.file}`, `push pattern ${options.file}`, format);
+        process.exit(1);
+    }
+
+    try {
+        const result = options.id
+            ? await pushPatternVersioned(client, options, fileContent, format)
+            : await client.pushPattern(options.namespace, options.name!, options.description!, fileContent);
+        printPushResult(result, format);
+    } catch (err) {
+        handleHubError(err, format);
+    }
+}
+
+// ── pull pattern ──────────────────────────────────────────────────────────────
+
+export interface PullPatternOptions {
+    calmHubOptions: CalmHubOptions;
+    namespace: string;
+    id: string;
+    version: string;
+    output?: string;
+}
+
+/**
+ * Pulls a pattern version from CALM Hub and writes it to stdout or a file.
+ * @param options Command options.
+ */
+export async function runPullPattern(options: PullPatternOptions): Promise<void> {
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, 'json');
+    const client = new CalmHubClient(calmHubOptions);
+
+    const parsedId = parseInt(options.id, 10);
+    if (!Number.isFinite(parsedId)) {
+        printError(0, '--id must be a valid integer', 'pull pattern', 'json');
+        process.exit(1);
+    }
+
+    try {
+        const result = await client.pullPattern(options.namespace, parsedId, options.version);
+        const pretty = JSON.stringify(result, null, 2);
+
+        if (options.output) {
+            await writeFile(options.output, pretty, 'utf-8');
+        } else {
+            console.log(pretty);
+        }
+    } catch (err) {
+        handleHubError(err, 'json');
+    }
+}
+
+// ── list patterns ─────────────────────────────────────────────────────────────
+
+export interface ListPatternsOptions {
+    calmHubOptions: CalmHubOptions;
+    namespace: string;
+    format?: string;
+}
+
+/**
+ * Lists patterns in a namespace.
+ * @param options Command options.
+ */
+export async function runListPatterns(options: ListPatternsOptions): Promise<void> {
+    const format: OutputFormat = parseOutputFormat(options.format);
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
+
+    try {
+        const patterns = await client.listPatterns(options.namespace);
+
+        if (format === 'pretty') {
+            printTableSuccess(
+                patterns.map(p => ({ ID: p.id, NAME: p.name, VERSIONS: p.versions.join(', ') })),
+                [
+                    { key: 'ID', header: 'ID' },
+                    { key: 'NAME', header: 'NAME' },
+                    { key: 'VERSIONS', header: 'VERSIONS' }
+                ]
+            );
+        } else {
+            printJsonSuccess(patterns);
+        }
+    } catch (err) {
+        handleHubError(err, format);
+    }
+}
+
+// ── push standard ─────────────────────────────────────────────────────────────
+
+export interface PushStandardOptions {
+    calmHubOptions: CalmHubOptions;
+    namespace: string;
+    name?: string;
+    description?: string;
+    file: string;
+    id?: string;
+    version?: string;
+    format?: string;
+}
+
+/**
+ * Resolves missing standard name/description from an existing standard id.
+ * @param client CALM Hub API client.
+ * @param namespace Target namespace.
+ * @param parsedId Standard id.
+ * @param name Optional name supplied by the user.
+ * @param description Optional description supplied by the user.
+ * @param format Output format used for error handling.
+ * @returns Resolved name and description.
+ */
+export async function resolveStandardMetadata(
+    client: CalmHubClient,
+    namespace: string,
+    parsedId: number,
+    name: string | undefined,
+    description: string | undefined,
+    format: OutputFormat
+): Promise<{ name: string; description: string }> {
+    if (name && description !== undefined) {
+        return { name, description };
+    }
+
+    let standards: HubStandardSummary[] = [];
+    try {
+        standards = await client.listStandards(namespace);
+    } catch (err) {
+        handleHubError(err, format);
+    }
+    const existing = standards.find(s => s.id === parsedId);
+    if (!existing) {
+        printError(0, `Standard with id ${parsedId} not found in namespace ${namespace}`, 'push standard', format);
+        process.exit(1);
+    }
+    return {
+        name: name ?? existing.name,
+        description: description ?? existing.description ?? ''
+    };
+}
+
+/**
+ * Pushes a new standard version for an existing standard id.
+ * @param client CALM Hub API client.
+ * @param options Command options.
+ * @param fileContent Standard JSON payload.
+ * @param format Output format used for error handling.
+ * @returns Push result with id, version, and location.
+ */
+export async function pushStandardVersioned(
+    client: CalmHubClient,
+    options: PushStandardOptions,
+    fileContent: string,
+    format: OutputFormat
+): Promise<PushArchitectureResult> {
+    if (!options.version) {
+        printError(0, '--ver is required when --id is provided', 'push standard', format);
+        process.exit(1);
+    }
+
+    const parsedId = parseInt(options.id!, 10);
+    if (!Number.isFinite(parsedId)) {
+        printError(0, '--id must be a valid integer', 'push standard', format);
+        process.exit(1);
+    }
+
+    const { name, description } = await resolveStandardMetadata(
+        client,
+        options.namespace,
+        parsedId,
+        options.name,
+        options.description,
+        format
+    );
+
+    return client.pushStandardVersion(
+        options.namespace,
+        parsedId,
+        options.version,
+        name,
+        description,
+        fileContent
+    );
+}
+
+/**
+ * Pushes a new standard or a versioned update to CALM Hub.
+ * @param options Command options.
+ */
+export async function runPushStandard(options: PushStandardOptions): Promise<void> {
+    const format: OutputFormat = parseOutputFormat(options.format);
+
+    if (!options.id && !options.name) {
+        printError(0, '--name is required when creating a new standard', 'push standard', format);
+        process.exit(1);
+    }
+
+    if (!options.id && !options.description) {
+        printError(0, '--description is required when creating a new standard', 'push standard', format);
+        process.exit(1);
+    }
+
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
+
+    let fileContent: string;
+    try {
+        fileContent = await readFile(options.file, 'utf-8');
+    } catch {
+        printError(0, `Could not read file: ${options.file}`, `push standard ${options.file}`, format);
+        process.exit(1);
+    }
+
+    try {
+        JSON.parse(fileContent);
+    } catch {
+        printError(0, `File is not valid JSON: ${options.file}`, `push standard ${options.file}`, format);
+        process.exit(1);
+    }
+
+    try {
+        const result = options.id
+            ? await pushStandardVersioned(client, options, fileContent, format)
+            : await client.pushStandard(options.namespace, options.name!, options.description!, fileContent);
+        printPushResult(result, format);
+    } catch (err) {
+        handleHubError(err, format);
+    }
+}
+
+// ── pull standard ─────────────────────────────────────────────────────────────
+
+export interface PullStandardOptions {
+    calmHubOptions: CalmHubOptions;
+    namespace: string;
+    id: string;
+    version: string;
+    output?: string;
+}
+
+/**
+ * Pulls a standard version from CALM Hub and writes it to stdout or a file.
+ * @param options Command options.
+ */
+export async function runPullStandard(options: PullStandardOptions): Promise<void> {
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, 'json');
+    const client = new CalmHubClient(calmHubOptions);
+
+    const parsedId = parseInt(options.id, 10);
+    if (!Number.isFinite(parsedId)) {
+        printError(0, '--id must be a valid integer', 'pull standard', 'json');
+        process.exit(1);
+    }
+
+    try {
+        const result = await client.pullStandard(options.namespace, parsedId, options.version);
+        const pretty = JSON.stringify(result, null, 2);
+
+        if (options.output) {
+            await writeFile(options.output, pretty, 'utf-8');
+        } else {
+            console.log(pretty);
+        }
+    } catch (err) {
+        handleHubError(err, 'json');
+    }
+}
+
+// ── list standards ────────────────────────────────────────────────────────────
+
+export interface ListStandardsOptions {
+    calmHubOptions: CalmHubOptions;
+    namespace: string;
+    format?: string;
+}
+
+/**
+ * Lists standards in a namespace.
+ * @param options Command options.
+ */
+export async function runListStandards(options: ListStandardsOptions): Promise<void> {
+    const format: OutputFormat = parseOutputFormat(options.format);
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
+
+    try {
+        const standards = await client.listStandards(options.namespace);
+
+        if (format === 'pretty') {
+            printTableSuccess(
+                standards.map(s => ({ ID: s.id, NAME: s.name, DESCRIPTION: s.description ?? '', VERSIONS: s.versions.join(', ') })),
+                [
+                    { key: 'ID', header: 'ID' },
+                    { key: 'NAME', header: 'NAME' },
+                    { key: 'DESCRIPTION', header: 'DESCRIPTION' },
+                    { key: 'VERSIONS', header: 'VERSIONS' }
+                ]
+            );
+        } else {
+            printJsonSuccess(standards);
+        }
+    } catch (err) {
+        handleHubError(err, format);
+    }
+}
+
+// ── create domain ───────────────────────────────────────────────────────────
+
+export interface CreateDomainOptions {
+    calmHubOptions: CalmHubOptions;
+    name: string;
+    format?: string;
+}
+
+/**
+ * Prints an id-based creation result in either pretty table or JSON format.
+ * @param result Creation result payload.
+ * @param format Output format selector.
+ */
+export function printIdCreateResult(result: { id: number; location: string }, format: OutputFormat): void {
+    if (format === 'pretty') {
+        printTableSuccess(
+            [{ STATUS: 'Created', ID: result.id, LOCATION: result.location }],
+            [
+                { key: 'STATUS', header: 'STATUS' },
+                { key: 'ID', header: 'ID' },
+                { key: 'LOCATION', header: 'LOCATION' }
+            ]
+        );
+    } else {
+        printJsonSuccess({ id: result.id, location: result.location });
+    }
+}
+
+/**
+ * Creates a domain in CALM Hub.
+ * @param options Command options.
+ */
+export async function runCreateDomain(options: CreateDomainOptions): Promise<void> {
+    const format: OutputFormat = parseOutputFormat(options.format);
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
+
+    try {
+        const result: HubDomainCreateResult = await client.createDomain(options.name);
+        if (format === 'pretty') {
+            printTableSuccess(
+                [{ STATUS: 'Created', NAME: result.name, LOCATION: result.location }],
+                [
+                    { key: 'STATUS', header: 'STATUS' },
+                    { key: 'NAME', header: 'NAME' },
+                    { key: 'LOCATION', header: 'LOCATION' }
+                ]
+            );
+        } else {
+            printJsonSuccess({ name: result.name, location: result.location });
+        }
+    } catch (err) {
+        handleHubError(err, format);
+    }
+}
+
+// ── list domains ─────────────────────────────────────────────────────────────
+
+export interface ListDomainsOptions {
+    calmHubOptions: CalmHubOptions;
+    format?: string;
+}
+
+/**
+ * Lists domains in CALM Hub.
+ * @param options Command options.
+ */
+export async function runListDomains(options: ListDomainsOptions): Promise<void> {
+    const format: OutputFormat = parseOutputFormat(options.format);
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
+
+    try {
+        const domains: HubDomainSummary[] = await client.listDomains();
+
+        if (format === 'pretty') {
+            printTableSuccess(
+                domains.map(d => ({ NAME: d.name })),
+                [{ key: 'NAME', header: 'NAME' }]
+            );
+        } else {
+            printJsonSuccess(domains);
+        }
+    } catch (err) {
+        handleHubError(err, format);
+    }
+}
+
+// ── create control ────────────────────────────────────────────────────────────
+
+export interface CreateControlRequirementOptions {
+    calmHubOptions: CalmHubOptions;
+    domain: string;
+    name: string;
+    description: string;
+    file: string;
+    format?: string;
+}
+
+/**
+ * Creates a control requirement from a local JSON file.
+ * @param options Command options.
+ */
+export async function runCreateControlRequirement(options: CreateControlRequirementOptions): Promise<void> {
+    const format: OutputFormat = parseOutputFormat(options.format);
+
+    if (!options.name?.trim()) {
+        handleHubError(new Error('--name is required and must not be blank'), format);
+    }
+    if (!options.description?.trim()) {
+        handleHubError(new Error('--description is required and must not be blank'), format);
+    }
+
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
+
+    let fileContent: string;
+    try {
+        fileContent = await readFile(options.file, 'utf-8');
+    } catch {
+        printError(0, `Could not read file: ${options.file}`, `create control-requirement ${options.file}`, format);
+        process.exit(1);
+    }
+
+    try {
+        JSON.parse(fileContent);
+    } catch {
+        printError(0, `File is not valid JSON: ${options.file}`, `create control-requirement ${options.file}`, format);
+        process.exit(1);
+    }
+
+    try {
+        const result = await client.createControl(options.domain, options.name, options.description, fileContent);
+        printIdCreateResult(result, format);
+    } catch (err) {
+        handleHubError(err, format);
+    }
+}
+
+// ── list controls ─────────────────────────────────────────────────────────────
+
+export interface ListControlRequirementsOptions {
+    calmHubOptions: CalmHubOptions;
+    domain: string;
+    format?: string;
+}
+
+/**
+ * Lists controls for a domain.
+ * @param options Command options.
+ */
+export async function runListControlRequirements(options: ListControlRequirementsOptions): Promise<void> {
+    const format: OutputFormat = parseOutputFormat(options.format);
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
+
+    try {
+        const controls: HubControlRequirementSummary[] = await client.listControlRequirements(options.domain);
+
+        if (format === 'pretty') {
+            printTableSuccess(
+                controls.map(c => ({
+                    'CONTROL-ID': c['control-id'],
+                    NAME: c.name,
+                    DESCRIPTION: c.description ?? '',
+                    VERSIONS: c.versions.join(', ')
+                })),
+                [
+                    { key: 'CONTROL-ID', header: 'CONTROL-ID' },
+                    { key: 'NAME', header: 'NAME' },
+                    { key: 'DESCRIPTION', header: 'DESCRIPTION' },
+                    { key: 'VERSIONS', header: 'VERSIONS' }
+                ]
+            );
+        } else {
+            printJsonSuccess(controls);
+        }
+    } catch (err) {
+        handleHubError(err, format);
+    }
+}
+
+// ── push control-requirement ──────────────────────────────────────────────────
+
+export interface PushControlRequirementOptions {
+    calmHubOptions: CalmHubOptions;
+    domain: string;
+    controlId: string;
+    version: string;
+    name?: string;
+    description?: string;
+    file: string;
+    format?: string;
+}
+
+/**
+ * Pushes a versioned control requirement from a local JSON file.
+ * @param options Command options.
+ */
+export async function runPushControlRequirement(options: PushControlRequirementOptions): Promise<void> {
+    const format: OutputFormat = parseOutputFormat(options.format);
+
+    const parsedControlId = parseInt(options.controlId, 10);
+    if (!Number.isFinite(parsedControlId)) {
+        printError(0, '--control-id must be a valid integer', 'push control-requirement', format);
+        process.exit(1);
+    }
+
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
+
+    let fileContent: string;
+    try {
+        fileContent = await readFile(options.file, 'utf-8');
+    } catch {
+        printError(0, `Could not read file: ${options.file}`, `push control-requirement ${options.file}`, format);
+        process.exit(1);
+    }
+
+    try {
+        JSON.parse(fileContent);
+    } catch {
+        printError(0, `File is not valid JSON: ${options.file}`, `push control-requirement ${options.file}`, format);
+        process.exit(1);
+    }
+
+    try {
+        const trimmedName = options.name?.trim();
+        const trimmedDescription = options.description?.trim();
+
+        let resolvedName = trimmedName;
+        let resolvedDescription = trimmedDescription;
+
+        if (!resolvedName || !resolvedDescription) {
+            const controls = await client.listControls(options.domain);
+            const matchingControl = controls.find(control => control.id === parsedControlId);
+
+            if (!matchingControl) {
+                printError(
+                    0,
+                    `Control with id ${parsedControlId} not found in domain ${options.domain}`,
+                    'push control-requirement',
+                    format
+                );
+                process.exit(1);
+            }
+
+            if (!resolvedName) {
+                resolvedName = matchingControl.name?.trim();
+            }
+
+            if (!resolvedDescription) {
+                resolvedDescription = matchingControl.description?.trim();
+            }
+
+            if (!resolvedName || !resolvedDescription) {
+                printError(
+                    0,
+                    `Control with id ${parsedControlId} in domain ${options.domain} is missing name or description`,
+                    'push control-requirement',
+                    format
+                );
+                process.exit(1);
+            }
+        }
+
+        const result = await client.pushControlRequirement(
+            options.domain,
+            parsedControlId,
+            options.version,
+            resolvedName,
+            resolvedDescription,
+            fileContent
+        );
+        printPushResult(result, format);
+    } catch (err) {
+        handleHubError(err, format);
+    }
+}
+
+// ── pull control-requirement ──────────────────────────────────────────────────
+
+export interface PullControlRequirementOptions {
+    calmHubOptions: CalmHubOptions;
+    domain: string;
+    controlId: string;
+    version: string;
+    output?: string;
+}
+
+/**
+ * Pulls a versioned control requirement and writes it to stdout or a file.
+ * @param options Command options.
+ */
+export async function runPullControlRequirement(options: PullControlRequirementOptions): Promise<void> {
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, 'json');
+    const client = new CalmHubClient(calmHubOptions);
+
+    const parsedControlId = parseInt(options.controlId, 10);
+    if (!Number.isFinite(parsedControlId)) {
+        printError(0, '--control-id must be a valid integer', 'pull control-requirement', 'json');
+        process.exit(1);
+    }
+
+    try {
+        const result = await client.pullControlRequirement(options.domain, parsedControlId, options.version);
+        const pretty = JSON.stringify(result, null, 2);
+
+        if (options.output) {
+            await writeFile(options.output, pretty, 'utf-8');
+        } else {
+            console.log(pretty);
+        }
+    } catch (err) {
+        handleHubError(err, 'json');
+    }
+}
+
+// ── push control-configuration ───────────────────────────────────────────────
+
+export interface PushControlConfigurationOptions {
+    calmHubOptions: CalmHubOptions;
+    domain: string;
+    controlId: string;
+    configId: string;
+    version: string;
+    file: string;
+    format?: string;
+}
+
+/**
+ * Pushes a versioned control configuration from a local JSON file.
+ * @param options Command options.
+ */
+export async function runPushControlConfiguration(options: PushControlConfigurationOptions): Promise<void> {
+    const format: OutputFormat = parseOutputFormat(options.format);
+
+    const parsedControlId = parseInt(options.controlId, 10);
+    if (!Number.isFinite(parsedControlId)) {
+        printError(0, '--control-id must be a valid integer', 'push control-configuration', format);
+        process.exit(1);
+    }
+
+    const parsedConfigId = parseInt(options.configId, 10);
+    if (!Number.isFinite(parsedConfigId)) {
+        printError(0, '--config-id must be a valid integer', 'push control-configuration', format);
+        process.exit(1);
+    }
+
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
+
+    let fileContent: string;
+    try {
+        fileContent = await readFile(options.file, 'utf-8');
+    } catch {
+        printError(0, `Could not read file: ${options.file}`, `push control-configuration ${options.file}`, format);
+        process.exit(1);
+    }
+
+    try {
+        JSON.parse(fileContent);
+    } catch {
+        printError(0, `File is not valid JSON: ${options.file}`, `push control-configuration ${options.file}`, format);
+        process.exit(1);
+    }
+
+    try {
+        const result = await client.pushControlConfiguration(options.domain, parsedControlId, parsedConfigId, options.version, fileContent);
+        printPushResult(result, format);
+    } catch (err) {
+        handleHubError(err, format);
+    }
+}
+
+// ── pull control-configuration ───────────────────────────────────────────────
+
+export interface PullControlConfigurationOptions {
+    calmHubOptions: CalmHubOptions;
+    domain: string;
+    controlId: string;
+    configId: string;
+    version: string;
+    output?: string;
+}
+
+/**
+ * Pulls a versioned control configuration and writes it to stdout or a file.
+ * @param options Command options.
+ */
+export async function runPullControlConfiguration(options: PullControlConfigurationOptions): Promise<void> {
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, 'json');
+    const client = new CalmHubClient(calmHubOptions);
+
+    const parsedControlId = parseInt(options.controlId, 10);
+    if (!Number.isFinite(parsedControlId)) {
+        printError(0, '--control-id must be a valid integer', 'pull control-configuration', 'json');
+        process.exit(1);
+    }
+
+    const parsedConfigId = parseInt(options.configId, 10);
+    if (!Number.isFinite(parsedConfigId)) {
+        printError(0, '--config-id must be a valid integer', 'pull control-configuration', 'json');
+        process.exit(1);
+    }
+
+    try {
+        const result = await client.pullControlConfiguration(options.domain, parsedControlId, parsedConfigId, options.version);
+        const pretty = JSON.stringify(result, null, 2);
+
+        if (options.output) {
+            await writeFile(options.output, pretty, 'utf-8');
+        } else {
+            console.log(pretty);
+        }
+    } catch (err) {
+        handleHubError(err, 'json');
+    }
+}
+
+// ── create control-configuration ──────────────────────────────────────────────
+
+export interface CreateControlConfigurationOptions {
+    calmHubOptions: CalmHubOptions;
+    domain: string;
+    controlId: string;
+    file: string;
+    format?: string;
+}
+
+/**
+ * Creates a control configuration from a local JSON file.
+ * @param options Command options.
+ */
+export async function runCreateControlConfiguration(options: CreateControlConfigurationOptions): Promise<void> {
+    const format: OutputFormat = parseOutputFormat(options.format);
+
+    const parsedControlId = parseInt(options.controlId, 10);
+    if (!Number.isFinite(parsedControlId)) {
+        printError(0, '--control-id must be a valid integer', 'create control-configuration', format);
+        process.exit(1);
+    }
+
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
+
+    let fileContent: string;
+    try {
+        fileContent = await readFile(options.file, 'utf-8');
+    } catch {
+        printError(0, `Could not read file: ${options.file}`, `create control-configuration ${options.file}`, format);
+        process.exit(1);
+    }
+
+    try {
+        JSON.parse(fileContent);
+    } catch {
+        printError(0, `File is not valid JSON: ${options.file}`, `create control-configuration ${options.file}`, format);
+        process.exit(1);
+    }
+
+    try {
+        const result = await client.createControlConfiguration(options.domain, parsedControlId, fileContent);
+        printIdCreateResult(result as { id: number; location: string }, format);
+    } catch (err) {
+        handleHubError(err, format);
+    }
+}
+
+// ── list control-configurations ───────────────────────────────────────────────
+
+export interface ListControlConfigurationsOptions {
+    calmHubOptions: CalmHubOptions;
+    domain: string;
+    controlId: string;
+    format?: string;
+}
+
+/**
+ * Summarizes a control configuration with the versions available for it.
+ */
+interface ControlConfigurationSummary {
+    configId: number;
+    versions: string[];
+}
+
+/**
+ * Lists control configurations for a control requirement, including the versions available for each configuration.
+ * @param options Command options.
+ */
+export async function runListControlConfigurations(options: ListControlConfigurationsOptions): Promise<void> {
+    const format: OutputFormat = parseOutputFormat(options.format);
+
+    const parsedControlId = parseInt(options.controlId, 10);
+    if (!Number.isFinite(parsedControlId)) {
+        printError(0, '--control-id must be a valid integer', 'list control-configurations', format);
+        process.exit(1);
+    }
+
+    const calmHubOptions = await handleOptionsLoadError(options.calmHubOptions, format);
+    const client = new CalmHubClient(calmHubOptions);
+
+    try {
+        const ids: number[] = await client.listControlConfigurations(options.domain, parsedControlId);
+        const sortedIds = [...ids].sort((a, b) => a - b);
+        const configurations: ControlConfigurationSummary[] = [];
+
+        for (const id of sortedIds) {
+            const versions = await client.listControlConfigurationVersions(options.domain, parsedControlId, id);
+            configurations.push({ configId: id, versions });
+        }
+
+        if (format === 'pretty') {
+            printTableSuccess(
+                configurations.map(configuration => ({
+                    'CONFIG-ID': configuration.configId,
+                    VERSIONS: configuration.versions.join(', ')
+                })),
+                [
+                    { key: 'CONFIG-ID', header: 'CONFIG-ID' },
+                    { key: 'VERSIONS', header: 'VERSIONS' }
+                ]
+            );
+        } else {
+            printJsonSuccess(configurations.map(c => ({ 'config-id': c.configId, versions: c.versions })));
+        }
+    } catch (err) {
+        handleHubError(err, format);
+    }
+}
+
 // ── shared error handler ──────────────────────────────────────────────────────
 
+/**
+ * Normalizes and prints Hub errors, then exits the process.
+ * @param err Thrown error.
+ * @param format Output format selector.
+ */
 function handleHubError(err: unknown, format: OutputFormat): never {
     if (err instanceof HubClientError || err instanceof HubCommandError) {
         printError(err.status, err.error, err.request, format);

--- a/cli/test_fixtures/hub/sample-control-config.json
+++ b/cli/test_fixtures/hub/sample-control-config.json
@@ -1,0 +1,4 @@
+{
+  "type": "control-configuration",
+  "config": {}
+}

--- a/cli/test_fixtures/hub/sample-control-requirement.json
+++ b/cli/test_fixtures/hub/sample-control-requirement.json
@@ -1,0 +1,4 @@
+{
+  "type": "control-requirement",
+  "requirements": []
+}

--- a/docs/docs/working-with-calm/cli.md
+++ b/docs/docs/working-with-calm/cli.md
@@ -344,11 +344,11 @@ calm docify -a my-architecture.json -o docs/output --scaffold
 
 ## Interacting with CALM Hub
 
-:::note
-The `hub` command group is under active development. Additional subcommands and features will be released in future versions.
+:::warning
+The `hub` command group is under active development.  Functionality may change without notice.
 :::
 
-The `hub` command group allows you to interact with a running `CALM Hub` instance directly from the CLI. You can use it to manage namespaces and push, pull, and list CALM architecture documents stored in CALM Hub.
+The `hub` command group allows you to interact with a running `CALM Hub` instance directly from the CLI. You can use it to manage Namespaces, Architectures, Standards, Patterns, Domains and Controls stored in CALM Hub.
 
 ### Connecting to CALM Hub
 
@@ -367,6 +367,8 @@ If `-c` is omitted, the CLI will look for a `calmHubUrl` property in `~/.calm.js
 ```
 
 ### Managing Namespaces
+
+Namespaces are used to organise architectures within CALM Hub.
 
 #### List namespaces
 
@@ -410,7 +412,7 @@ calm hub list architectures --namespace my-namespace -c http://localhost:8080
 
 - **`--namespace <namespace>`**: The namespace to list architectures from (default: `default`).
 - **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
-- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`. The `pretty` format renders results as an ASCII table with columns **ID**, **NAME**, and **VERSIONS**.
 
 #### Push an architecture
 
@@ -423,6 +425,8 @@ calm hub push architecture my-architecture.json \
   --namespace my-namespace \
   -c http://localhost:8080
 ```
+
+On success the command outputs the newly created architecture record, including the assigned ID.
 
 **Options:**
 
@@ -443,6 +447,8 @@ calm hub push architecture my-architecture.json \
   --namespace my-namespace \
   -c http://localhost:8080
 ```
+
+When `--id` is provided, `--name` and `--description` are not required — they are already associated with the existing architecture record.
 
 **Options:**
 
@@ -482,3 +488,411 @@ calm hub pull architecture \
 - **`--ver <version>`**: _(required)_ The version to retrieve (e.g. `1.0.0`).
 - **`-o, --output <file>`**: Write the architecture JSON to a file instead of stdout.
 - **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+
+### Managing Patterns
+
+#### List patterns
+
+To list all patterns stored in a namespace:
+
+```shell
+calm hub list patterns --namespace my-namespace -c http://localhost:8080
+```
+
+**Options:**
+
+- **`--namespace <namespace>`**: The namespace to list patterns from (default: `default`).
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`. The `pretty` format renders results as an ASCII table with columns **ID**, **NAME**, and **VERSIONS**.
+
+#### Push a pattern
+
+To publish a new pattern document to CALM Hub, provide the pattern file together with a name and description:
+
+```shell
+calm hub push pattern my-pattern.json \
+  --name "Payments Integration Pattern" \
+  --description "Reusable integration pattern for payments services" \
+  --namespace my-namespace \
+  -c http://localhost:8080
+```
+
+On success the command outputs the newly created pattern record, including the assigned ID.
+
+**Options:**
+
+- **`--name <name>`**: _(required when creating a new pattern)_ Display name for the pattern.
+- **`--description <description>`**: _(required when creating a new pattern)_ Short description of the pattern.
+- **`--namespace <namespace>`**: Target namespace (default: `default`).
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`.
+
+#### Push a new version of an existing pattern
+
+To add a new version to a pattern that already exists in CALM Hub, use `--id` to identify the existing record and `--ver` to specify the semver version string:
+
+```shell
+calm hub push pattern my-pattern.json \
+  --id <pattern-id> \
+  --ver 1.1.0 \
+  --namespace my-namespace \
+  -c http://localhost:8080
+```
+
+When `--id` is provided, `--name` and `--description` are not required — they are already associated with the existing pattern record.
+
+**Options:**
+
+- **`--id <id>`**: The ID of the existing pattern to add a version to.
+- **`--ver <version>`**: _(required when `--id` is provided)_ The semver version string for the new version (e.g. `1.1.0`).
+- **`--namespace <namespace>`**: Target namespace (default: `default`).
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`.
+
+#### Pull a pattern
+
+To download a specific version of a pattern from CALM Hub, provide the namespace, pattern ID, and version:
+
+```shell
+calm hub pull pattern \
+  --namespace my-namespace \
+  --id <pattern-id> \
+  --ver 1.0.0 \
+  -c http://localhost:8080
+```
+
+By default the pattern JSON is written to stdout. Use `-o` to write it to a file instead:
+
+```shell
+calm hub pull pattern \
+  --namespace my-namespace \
+  --id <pattern-id> \
+  --ver 1.0.0 \
+  -o pulled-pattern.json \
+  -c http://localhost:8080
+```
+
+**Options:**
+
+- **`--namespace <namespace>`**: _(required)_ The namespace the pattern belongs to.
+- **`--id <id>`**: _(required)_ The ID of the pattern to pull.
+- **`--ver <version>`**: _(required)_ The version to retrieve (e.g. `1.0.0`).
+- **`-o, --output <file>`**: Write the pattern JSON to a file instead of stdout.
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+
+### Managing Standards
+
+#### List standards
+
+To list all standards stored in a namespace:
+
+```shell
+calm hub list standards --namespace my-namespace -c http://localhost:8080
+```
+
+**Options:**
+
+- **`--namespace <namespace>`**: The namespace to list standards from (default: `default`).
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`. The `pretty` format renders results as an ASCII table with columns **ID**, **NAME**, **DESCRIPTION**, and **VERSIONS**.
+
+#### Push a standard
+
+To publish a new standard document to CALM Hub, provide the standard file together with a name and description:
+
+```shell
+calm hub push standard my-standard.json \
+  --name "Payments Service Standard" \
+  --description "Standard schema extensions for payments services" \
+  --namespace my-namespace \
+  -c http://localhost:8080
+```
+
+On success the command outputs the newly created standard record, including the assigned ID.
+
+**Options:**
+
+- **`--name <name>`**: _(required when creating a new standard)_ Display name for the standard.
+- **`--description <description>`**: _(required when creating a new standard)_ Short description of the standard.
+- **`--namespace <namespace>`**: Target namespace (default: `default`).
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`.
+
+#### Push a new version of an existing standard
+
+To add a new version to a standard that already exists in CALM Hub, use `--id` to identify the existing record and `--ver` to specify the semver version string:
+
+```shell
+calm hub push standard my-standard.json \
+  --id <standard-id> \
+  --ver 1.1.0 \
+  --namespace my-namespace \
+  -c http://localhost:8080
+```
+
+When `--id` is provided, `--name` and `--description` are not required — they are already associated with the existing standard record.
+
+If you provide `--name` and/or `--description` together with `--id`, CALM Hub updates the standard's stored metadata to those values when creating the new version. This means the standard's top-level name/description shown by `list standards` will reflect the latest values you pushed.
+
+**Options:**
+
+- **`--id <id>`**: The ID of the existing standard to add a version to.
+- **`--ver <version>`**: _(required when `--id` is provided)_ The semver version string for the new version (e.g. `1.1.0`).
+- **`--namespace <namespace>`**: Target namespace (default: `default`).
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`.
+
+#### Pull a standard
+
+To download a specific version of a standard from CALM Hub, provide the namespace, standard ID, and version:
+
+```shell
+calm hub pull standard \
+  --namespace my-namespace \
+  --id <standard-id> \
+  --ver 1.0.0 \
+  -c http://localhost:8080
+```
+
+By default the standard JSON is written to stdout. Use `-o` to write it to a file instead:
+
+```shell
+calm hub pull standard \
+  --namespace my-namespace \
+  --id <standard-id> \
+  --ver 1.0.0 \
+  -o pulled-standard.json \
+  -c http://localhost:8080
+```
+
+**Options:**
+
+- **`--namespace <namespace>`**: _(required)_ The namespace the standard belongs to.
+- **`--id <id>`**: _(required)_ The ID of the standard to pull.
+- **`--ver <version>`**: _(required)_ The version to retrieve (e.g. `1.0.0`).
+- **`-o, --output <file>`**: Write the standard JSON to a file instead of stdout.
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+
+### Managing Domains
+
+Domains are used to organise controls in CALM Hub.
+
+#### List domains
+
+To list all domains:
+
+```shell
+calm hub list domains -c http://localhost:8080
+```
+
+**Options:**
+
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`. The `pretty` format renders results as an ASCII table with column **NAME**.
+
+#### Create a domain
+
+To create a new domain, provide a name:
+
+```shell
+calm hub create domain --name risk -c http://localhost:8080
+```
+
+**Options:**
+
+- **`--name <name>`**: _(required)_ The name of the domain to create.
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`.
+
+### Managing Control Requirements
+
+Control requirements are managed within a domain and identified by a numeric control ID.
+
+#### List control requirements
+
+To list all control requirements in a domain:
+
+```shell
+calm hub list control-requirements --domain risk -c http://localhost:8080
+```
+
+**Options:**
+
+- **`--domain <domain>`**: _(required)_ The domain to list control requirements from.
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`. The `pretty` format renders results as an ASCII table with columns **ID**, **NAME**, **DESCRIPTION**, and **VERSIONS**.
+
+#### Create a control requirement
+
+To create a new control requirement, provide the requirement JSON file together with domain, name, and description:
+
+```shell
+calm hub create control-requirement my-control-requirement.json \
+  --domain risk \
+  --name "MFA Required for Privileged Access" \
+  --description "Administrative access must use multi-factor authentication" \
+  -c http://localhost:8080
+```
+
+**Options:**
+
+- **`--domain <domain>`**: _(required)_ The target domain.
+- **`--name <name>`**: _(required)_ Control name.
+- **`--description <description>`**: _(required)_ Control description.
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`.
+
+#### Push a control requirement version
+
+To add a new version to an existing control requirement, provide the requirement file with domain, control ID, and version:
+
+```shell
+calm hub push control-requirement my-control-requirement.json \
+  --domain risk \
+  --control-id 42 \
+  --ver 1.1.0 \
+  -c http://localhost:8080
+```
+
+You can optionally provide `--name` and `--description` for the version wrapper. If omitted, the CLI resolves them from the existing control metadata.
+
+**Options:**
+
+- **`--domain <domain>`**: _(required)_ The target domain.
+- **`--control-id <id>`**: _(required)_ The numeric control ID.
+- **`--ver <version>`**: _(required)_ The semver version string for the new requirement version.
+- **`--name <name>`**: Optional name for the requirement version wrapper.
+- **`--description <description>`**: Optional description for the requirement version wrapper.
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`.
+
+#### Pull a control requirement version
+
+To download a specific version of a control requirement:
+
+```shell
+calm hub pull control-requirement \
+  --domain risk \
+  --control-id 42 \
+  --ver 1.0.0 \
+  -c http://localhost:8080
+```
+
+By default the requirement JSON is written to stdout. Use `-o` to write it to a file instead:
+
+```shell
+calm hub pull control-requirement \
+  --domain risk \
+  --control-id 42 \
+  --ver 1.0.0 \
+  -o pulled-control-requirement.json \
+  -c http://localhost:8080
+```
+
+**Options:**
+
+- **`--domain <domain>`**: _(required)_ The source domain.
+- **`--control-id <id>`**: _(required)_ The numeric control ID.
+- **`--ver <version>`**: _(required)_ The requirement version to retrieve.
+- **`-o, --output <file>`**: Write the requirement JSON to a file instead of stdout.
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+
+### Managing Control Configurations
+
+Control configurations are managed per control requirement and identified by a numeric configuration ID.
+
+#### List control configurations
+
+To list all control configurations and their versions for a control requirement:
+
+```shell
+calm hub list control-configurations --domain risk --control-id 42 -c http://localhost:8080
+```
+
+**Options:**
+
+- **`--domain <domain>`**: _(required)_ The target domain.
+- **`--control-id <id>`**: _(required)_ The numeric control ID.
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`. The `pretty` format renders results as an ASCII table with columns **CONFIG-ID** and **VERSIONS**.
+
+#### Create a control configuration
+
+To create a new control configuration for a control requirement:
+
+```shell
+calm hub create control-configuration my-control-configuration.json \
+  --domain risk \
+  --control-id 42 \
+  -c http://localhost:8080
+```
+
+**Options:**
+
+- **`--domain <domain>`**: _(required)_ The target domain.
+- **`--control-id <id>`**: _(required)_ The numeric control ID.
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`.
+
+####Push a control configuration version
+
+To add a new version to an existing control configuration:
+
+```shell
+calm hub push control-configuration my-control-configuration.json \
+  --domain risk \
+  --control-id 42 \
+  --config-id 7 \
+  --ver 1.1.0 \
+  -c http://localhost:8080
+```
+
+**Options:**
+
+- **`--domain <domain>`**: _(required)_ The target domain.
+- **`--control-id <id>`**: _(required)_ The numeric control ID.
+- **`--config-id <id>`**: _(required)_ The numeric configuration ID.
+- **`--ver <version>`**: _(required)_ The semver version string for the new configuration version.
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+- **`-f, --format <format>`**: Output format — `json` (default) or `pretty`.
+
+#### Pull a control configuration version
+
+To download a specific version of a control configuration:
+
+```shell
+calm hub pull control-configuration \
+  --domain risk \
+  --control-id 42 \
+  --config-id 7 \
+  --ver 1.0.0 \
+  -c http://localhost:8080
+```
+
+By default the configuration JSON is written to stdout. Use `-o` to write it to a file instead:
+
+```shell
+calm hub pull control-configuration \
+  --domain risk \
+  --control-id 42 \
+  --config-id 7 \
+  --ver 1.0.0 \
+  -o pulled-control-configuration.json \
+  -c http://localhost:8080
+```
+
+**Options:**
+
+- **`--domain <domain>`**: _(required)_ The source domain.
+- **`--control-id <id>`**: _(required)_ The numeric control ID.
+- **`--config-id <id>`**: _(required)_ The numeric configuration ID.
+- **`--ver <version>`**: _(required)_ The configuration version to retrieve.
+- **`-o, --output <file>`**: Write the configuration JSON to a file instead of stdout.
+- **`-c, --calm-hub-url <url>`**: URL to the CALM Hub instance.
+
+### Output Formats
+
+All `hub` subcommands support a `-f, --format <format>` option with two choices:
+
+- **`json`** _(default)_ — outputs the raw JSON response from CALM Hub. Suitable for piping into other tools or scripts.
+- **`pretty`** — renders the output as a human-readable ASCII table. Available for `list` commands; for `push`, `pull`, and `create` commands it formats the response in a more readable way.

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
                 "fetch-mock": "^12.5.2",
                 "globals": "^16.0.0",
                 "husky": "^9.1.7",
+                "jsdom": "^26.0.0",
                 "link": "^2.1.1",
                 "memfs": "^4.17.0",
                 "msw": "^2.7.3",
@@ -143,46 +144,6 @@
             },
             "peerDependencies": {
                 "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-            }
-        },
-        "calm-hub-ui/node_modules/jsdom": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cssstyle": "^4.2.1",
-                "data-urls": "^5.0.0",
-                "decimal.js": "^10.5.0",
-                "html-encoding-sniffer": "^4.0.0",
-                "http-proxy-agent": "^7.0.2",
-                "https-proxy-agent": "^7.0.6",
-                "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.16",
-                "parse5": "^7.2.1",
-                "rrweb-cssom": "^0.8.0",
-                "saxes": "^6.0.0",
-                "symbol-tree": "^3.2.4",
-                "tough-cookie": "^5.1.1",
-                "w3c-xmlserializer": "^5.0.0",
-                "webidl-conversions": "^7.0.0",
-                "whatwg-encoding": "^3.1.1",
-                "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^14.1.1",
-                "ws": "^8.18.0",
-                "xml-name-validator": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "canvas": "^3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "canvas": {
-                    "optional": true
-                }
             }
         },
         "calm-hub-ui/node_modules/lucide-react": {
@@ -332,45 +293,6 @@
             },
             "engines": {
                 "vscode": "^1.88.0"
-            }
-        },
-        "calm-plugins/vscode/node_modules/jsdom": {
-            "version": "26.1.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
-            "license": "MIT",
-            "dependencies": {
-                "cssstyle": "^4.2.1",
-                "data-urls": "^5.0.0",
-                "decimal.js": "^10.5.0",
-                "html-encoding-sniffer": "^4.0.0",
-                "http-proxy-agent": "^7.0.2",
-                "https-proxy-agent": "^7.0.6",
-                "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.16",
-                "parse5": "^7.2.1",
-                "rrweb-cssom": "^0.8.0",
-                "saxes": "^6.0.0",
-                "symbol-tree": "^3.2.4",
-                "tough-cookie": "^5.1.1",
-                "w3c-xmlserializer": "^5.0.0",
-                "webidl-conversions": "^7.0.0",
-                "whatwg-encoding": "^3.1.1",
-                "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^14.1.1",
-                "ws": "^8.18.0",
-                "xml-name-validator": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "canvas": "^3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "canvas": {
-                    "optional": true
-                }
             }
         },
         "calm-server": {
@@ -539,6 +461,138 @@
                 "node": ">=20.0"
             }
         },
+        "calm-suite/calm-guard/node_modules/@asamuzakjp/css-color": {
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/@csstools/color-helpers": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+            "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/@csstools/css-calc": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+            "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/@csstools/css-color-parser": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+            "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^6.0.2",
+                "@csstools/css-calc": "^3.2.1"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
         "calm-suite/calm-guard/node_modules/@docusaurus/theme-mermaid": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.10.1.tgz",
@@ -617,6 +671,49 @@
                 "node": ">= 6"
             }
         },
+        "calm-suite/calm-guard/node_modules/cssstyle": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+            "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^5.0.1",
+                "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+                "css-tree": "^3.1.0",
+                "lru-cache": "^11.2.6"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/data-urls": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "calm-suite/calm-guard/node_modules/estree-walker": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -625,6 +722,129 @@
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/jsdom": {
+            "version": "28.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+            "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@acemir/cssom": "^0.9.31",
+                "@asamuzakjp/dom-selector": "^6.8.1",
+                "@bramus/specificity": "^2.4.2",
+                "@exodus/bytes": "^1.11.0",
+                "cssstyle": "^6.0.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "parse5": "^8.0.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.0",
+                "undici": "^7.21.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "calm-suite/calm-guard/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/tldts": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.0.tgz",
+            "integrity": "sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.4.0"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/tldts-core": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.1.tgz",
+            "integrity": "sha512-sc2nGvGbixlJRHwTh/qQdPXTxJU1UDJboGPQm4d/01YUJ9r/u6aeIulQvEaxUlvKDN7hb1qCLjax+jhVAPLa/g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "calm-suite/calm-guard/node_modules/tough-cookie": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "calm-suite/calm-guard/node_modules/vitest": {
@@ -742,6 +962,41 @@
                 "vite": {
                     "optional": true
                 }
+            }
+        },
+        "calm-suite/calm-guard/node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "calm-suite/calm-guard/node_modules/whatwg-url": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "calm-suite/calm-studio/apps/studio": {
@@ -1058,6 +1313,7 @@
                 "copyfiles": "^2.4.1",
                 "execa": "^9.6.0",
                 "mkdirp": "^3.0.1",
+                "tree-dump": "^1.1.0",
                 "ts-node": "10.9.2"
             },
             "bin": {
@@ -15222,11 +15478,13 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15238,11 +15496,13 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15254,11 +15514,13 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15270,11 +15532,13 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15286,11 +15550,13 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15302,11 +15568,13 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15318,11 +15586,13 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15334,11 +15604,13 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15350,11 +15622,13 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15366,11 +15640,13 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15382,11 +15658,13 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -15398,11 +15676,13 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -24666,6 +24946,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24682,6 +24963,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24698,6 +24980,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24714,6 +24997,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24730,6 +25014,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24746,6 +25031,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24762,6 +25048,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24778,6 +25065,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24794,6 +25082,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24810,6 +25099,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24826,6 +25116,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24842,6 +25133,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24858,6 +25150,7 @@
             "cpu": [
                 "mips64el"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24874,6 +25167,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24890,6 +25184,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24906,6 +25201,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24922,6 +25218,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24938,6 +25235,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24954,6 +25252,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24970,6 +25269,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -24986,6 +25286,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -25002,6 +25303,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -25018,6 +25320,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -25034,6 +25337,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -25050,6 +25354,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -25066,6 +25371,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -29955,36 +30261,34 @@
             "license": "MIT"
         },
         "node_modules/jsdom": {
-            "version": "28.1.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
-            "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
-            "dev": true,
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
             "license": "MIT",
             "dependencies": {
-                "@acemir/cssom": "^0.9.31",
-                "@asamuzakjp/dom-selector": "^6.8.1",
-                "@bramus/specificity": "^2.4.2",
-                "@exodus/bytes": "^1.11.0",
-                "cssstyle": "^6.0.1",
-                "data-urls": "^7.0.0",
-                "decimal.js": "^10.6.0",
-                "html-encoding-sniffer": "^6.0.0",
+                "cssstyle": "^4.2.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.5.0",
+                "html-encoding-sniffer": "^4.0.0",
                 "http-proxy-agent": "^7.0.2",
                 "https-proxy-agent": "^7.0.6",
                 "is-potential-custom-element-name": "^1.0.1",
-                "parse5": "^8.0.0",
+                "nwsapi": "^2.2.16",
+                "parse5": "^7.2.1",
+                "rrweb-cssom": "^0.8.0",
                 "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
-                "tough-cookie": "^6.0.0",
-                "undici": "^7.21.0",
+                "tough-cookie": "^5.1.1",
                 "w3c-xmlserializer": "^5.0.0",
-                "webidl-conversions": "^8.0.1",
-                "whatwg-mimetype": "^5.0.0",
-                "whatwg-url": "^16.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.1.1",
+                "ws": "^8.18.0",
                 "xml-name-validator": "^5.0.0"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+                "node": ">=18"
             },
             "peerDependencies": {
                 "canvas": "^3.0.0"
@@ -29993,298 +30297,6 @@
                 "canvas": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/jsdom/node_modules/@asamuzakjp/css-color": {
-            "version": "5.1.11",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@asamuzakjp/generational-cache": "^1.0.1",
-                "@csstools/css-calc": "^3.2.0",
-                "@csstools/css-color-parser": "^4.1.0",
-                "@csstools/css-parser-algorithms": "^4.0.0",
-                "@csstools/css-tokenizer": "^4.0.0"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jsdom/node_modules/@csstools/color-helpers": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-            "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT-0",
-            "engines": {
-                "node": ">=20.19.0"
-            }
-        },
-        "node_modules/jsdom/node_modules/@csstools/css-calc": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
-            "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.19.0"
-            },
-            "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^4.0.0",
-                "@csstools/css-tokenizer": "^4.0.0"
-            }
-        },
-        "node_modules/jsdom/node_modules/@csstools/css-color-parser": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
-            "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@csstools/color-helpers": "^6.0.2",
-                "@csstools/css-calc": "^3.2.1"
-            },
-            "engines": {
-                "node": ">=20.19.0"
-            },
-            "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^4.0.0",
-                "@csstools/css-tokenizer": "^4.0.0"
-            }
-        },
-        "node_modules/jsdom/node_modules/@csstools/css-parser-algorithms": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.19.0"
-            },
-            "peerDependencies": {
-                "@csstools/css-tokenizer": "^4.0.0"
-            }
-        },
-        "node_modules/jsdom/node_modules/@csstools/css-tokenizer": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.19.0"
-            }
-        },
-        "node_modules/jsdom/node_modules/cssstyle": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
-            "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@asamuzakjp/css-color": "^5.0.1",
-                "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
-                "css-tree": "^3.1.0",
-                "lru-cache": "^11.2.6"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/jsdom/node_modules/data-urls": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-mimetype": "^5.0.0",
-                "whatwg-url": "^16.0.0"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jsdom/node_modules/entities": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=20.19.0"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/jsdom/node_modules/html-encoding-sniffer": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@exodus/bytes": "^1.6.0"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jsdom/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/jsdom/node_modules/parse5": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
-            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "entities": "^8.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/inikulin/parse5?sponsor=1"
-            }
-        },
-        "node_modules/jsdom/node_modules/tldts": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.0.tgz",
-            "integrity": "sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tldts-core": "^7.4.0"
-            },
-            "bin": {
-                "tldts": "bin/cli.js"
-            }
-        },
-        "node_modules/jsdom/node_modules/tldts-core": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.0.tgz",
-            "integrity": "sha512-/mb9kRld+x1sIMXxWNOAp5m6C+D4GrAORWlJkOJ5dElvxdN1eutz/o7qHLp9gFvDF4Y3/L2xeScoxz6AbEo8rQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/jsdom/node_modules/tough-cookie": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tldts": "^7.0.5"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/jsdom/node_modules/tr46": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "punycode": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/jsdom/node_modules/webidl-conversions": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/jsdom/node_modules/whatwg-mimetype": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/jsdom/node_modules/whatwg-url": {
-            "version": "16.0.1",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@exodus/bytes": "^1.11.0",
-                "tr46": "^6.0.0",
-                "webidl-conversions": "^8.0.1"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/jsep": {
@@ -37963,6 +37975,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -45830,11 +45843,13 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "aix"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -45846,11 +45861,13 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -45862,11 +45879,13 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -45878,11 +45897,13 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -45894,11 +45915,13 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -45910,11 +45933,13 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -45926,11 +45951,13 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -45942,11 +45969,13 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -45958,11 +45987,13 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -45974,11 +46005,13 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -45990,11 +46023,13 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46006,11 +46041,13 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46022,11 +46059,13 @@
             "cpu": [
                 "mips64el"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46038,11 +46077,13 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46054,11 +46095,13 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46070,11 +46113,13 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46086,11 +46131,13 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46102,11 +46149,13 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46118,11 +46167,13 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46134,11 +46185,13 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46150,11 +46203,13 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46166,11 +46221,13 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "openharmony"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46182,11 +46239,13 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "sunos"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46198,11 +46257,13 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46214,11 +46275,13 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -46230,11 +46293,13 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }

--- a/shared/src/hub/calm-hub-client.spec.ts
+++ b/shared/src/hub/calm-hub-client.spec.ts
@@ -301,4 +301,696 @@ describe('CalmHubClient', () => {
             expect(requestBody).toMatchObject(body);
         });
     });
+
+    // ── pushPattern ──────────────────────────────────────────────────────────
+
+    describe('pushPattern', () => {
+        const patternJson = JSON.stringify({ nodes: [] });
+
+        it('returns id, version and location on 201', async () => {
+            mock.onPost('/calm/namespaces/finos/patterns').reply(201, null, {
+                location: '/calm/namespaces/finos/patterns/10/versions/1.0.0'
+            });
+
+            const result = await client.pushPattern('finos', 'my-pattern', 'A desc', patternJson);
+            expect(result).toEqual({ id: 10, version: '1.0.0', location: '/calm/namespaces/finos/patterns/10/versions/1.0.0' });
+        });
+
+        it('sends correct body fields', async () => {
+            let capturedBody: unknown;
+            mock.onPost('/calm/namespaces/finos/patterns').reply((config) => {
+                capturedBody = JSON.parse(config.data as string);
+                return [201, null, { location: '/calm/namespaces/finos/patterns/1/versions/1.0.0' }];
+            });
+
+            await client.pushPattern('finos', 'my-pattern', 'desc', patternJson);
+            expect(capturedBody).toMatchObject({ name: 'my-pattern', description: 'desc', patternJson });
+        });
+
+        it('throws HubClientError(400) on bad request', async () => {
+            mock.onPost('/calm/namespaces/finos/patterns').reply(400, 'Bad request');
+            await expect(client.pushPattern('finos', 'bad', '', patternJson)).rejects.toMatchObject({
+                status: 400,
+                request: 'POST /calm/namespaces/finos/patterns'
+            });
+        });
+
+        it('throws HubClientError when location header is unparseable', async () => {
+            mock.onPost('/calm/namespaces/finos/patterns').reply(201, null, { location: '/bad' });
+            await expect(client.pushPattern('finos', 'x', '', patternJson)).rejects.toMatchObject({ status: 0 });
+        });
+    });
+
+    // ── pushPatternVersion ───────────────────────────────────────────────────
+
+    describe('pushPatternVersion', () => {
+        const patternJson = JSON.stringify({ nodes: [] });
+
+        it('returns id, version and location on 201', async () => {
+            mock.onPost('/calm/namespaces/finos/patterns/10/versions/2.0.0').reply(201, null, {
+                location: '/calm/namespaces/finos/patterns/10/versions/2.0.0'
+            });
+
+            const result = await client.pushPatternVersion('finos', 10, '2.0.0', 'my-pattern', '', patternJson);
+            expect(result).toEqual({ id: 10, version: '2.0.0', location: '/calm/namespaces/finos/patterns/10/versions/2.0.0' });
+        });
+
+        it('sends pattern metadata and patternJson in the request body', async () => {
+            let capturedBody: unknown;
+            mock.onPost('/calm/namespaces/finos/patterns/10/versions/2.0.0').reply((config) => {
+                capturedBody = JSON.parse(config.data as string);
+                return [201, null, { location: '/calm/namespaces/finos/patterns/10/versions/2.0.0' }];
+            });
+
+            await client.pushPatternVersion('finos', 10, '2.0.0', 'my-pattern', 'desc', patternJson);
+
+            expect(capturedBody).toEqual({
+                name: 'my-pattern',
+                description: 'desc',
+                patternJson
+            });
+        });
+
+        it('throws HubClientError(409) on duplicate version', async () => {
+            mock.onPost('/calm/namespaces/finos/patterns/10/versions/1.0.0').reply(409, 'Version already exists');
+            await expect(client.pushPatternVersion('finos', 10, '1.0.0', 'p', '', patternJson)).rejects.toMatchObject({ status: 409 });
+        });
+
+        it('throws HubClientError(404) when pattern id not found', async () => {
+            mock.onPost('/calm/namespaces/finos/patterns/99/versions/1.0.0').reply(404, 'Pattern not found');
+            await expect(client.pushPatternVersion('finos', 99, '1.0.0', 'p', '', patternJson)).rejects.toMatchObject({ status: 404 });
+        });
+    });
+
+    // ── listPatterns ─────────────────────────────────────────────────────────
+
+    describe('listPatterns', () => {
+        it('fetches versions per pattern and returns summaries', async () => {
+            mock.onGet('/calm/namespaces/finos/patterns').reply(200, {
+                values: [
+                    { id: 1, name: 'pattern-a', description: 'desc-a' },
+                    { id: 2, name: 'pattern-b', description: '' }
+                ]
+            });
+            mock.onGet('/calm/namespaces/finos/patterns/1/versions').reply(200, { values: ['1.0.0'] });
+            mock.onGet('/calm/namespaces/finos/patterns/2/versions').reply(200, { values: ['1.0.0', '2.0.0'] });
+
+            const result = await client.listPatterns('finos');
+            expect(result).toHaveLength(2);
+            expect(result[0]).toEqual({ id: 1, name: 'pattern-a', description: 'desc-a', versions: ['1.0.0'] });
+            expect(result[1]).toEqual({ id: 2, name: 'pattern-b', description: '', versions: ['1.0.0', '2.0.0'] });
+        });
+
+        it('returns empty array when no patterns exist', async () => {
+            mock.onGet('/calm/namespaces/finos/patterns').reply(200, { values: [] });
+            const result = await client.listPatterns('finos');
+            expect(result).toEqual([]);
+        });
+
+        it('throws HubClientError(404) for unknown namespace', async () => {
+            mock.onGet('/calm/namespaces/unknown/patterns').reply(404, 'Namespace not found');
+            await expect(client.listPatterns('unknown')).rejects.toMatchObject({ status: 404 });
+        });
+    });
+
+    // ── pullPattern ──────────────────────────────────────────────────────────
+
+    describe('pullPattern', () => {
+        it('returns the pattern detail object', async () => {
+            const detail = { id: 1, name: 'pattern-a', version: '1.0.0', patternJson: '{}' };
+            mock.onGet('/calm/namespaces/finos/patterns/1/versions/1.0.0').reply(200, detail);
+
+            const result = await client.pullPattern('finos', 1, '1.0.0');
+            expect(result).toEqual(detail);
+        });
+
+        it('throws HubClientError(404) when not found', async () => {
+            mock.onGet('/calm/namespaces/finos/patterns/99/versions/1.0.0').reply(404, 'Pattern not found');
+            await expect(client.pullPattern('finos', 99, '1.0.0')).rejects.toMatchObject({ status: 404 });
+        });
+    });
+
+    // ── pushStandard ─────────────────────────────────────────────────────────
+
+    describe('pushStandard', () => {
+        const standardJson = 'raw standard content';
+
+        it('returns id, version and location on 201', async () => {
+            mock.onPost('/calm/namespaces/finos/standards').reply(201, null, {
+                location: '/calm/namespaces/finos/standards/20/versions/1.0.0'
+            });
+
+            const result = await client.pushStandard('finos', 'my-standard', 'A desc', standardJson);
+            expect(result).toEqual({ id: 20, version: '1.0.0', location: '/calm/namespaces/finos/standards/20/versions/1.0.0' });
+        });
+
+        it('sends standardJson as a string field in the body', async () => {
+            let capturedBody: unknown;
+            mock.onPost('/calm/namespaces/finos/standards').reply((config) => {
+                capturedBody = JSON.parse(config.data as string);
+                return [201, null, { location: '/calm/namespaces/finos/standards/1/versions/1.0.0' }];
+            });
+
+            await client.pushStandard('finos', 'my-standard', 'desc', standardJson);
+            expect(capturedBody).toMatchObject({ name: 'my-standard', description: 'desc', standardJson });
+        });
+
+        it('throws HubClientError(400) on bad request', async () => {
+            mock.onPost('/calm/namespaces/finos/standards').reply(400, 'Bad request');
+            await expect(client.pushStandard('finos', 'bad', '', standardJson)).rejects.toMatchObject({
+                status: 400,
+                request: 'POST /calm/namespaces/finos/standards'
+            });
+        });
+
+        it('throws HubClientError when location header is unparseable', async () => {
+            mock.onPost('/calm/namespaces/finos/standards').reply(201, null, { location: '/bad' });
+            await expect(client.pushStandard('finos', 'x', '', standardJson)).rejects.toMatchObject({ status: 0 });
+        });
+    });
+
+    // ── pushStandardVersion ──────────────────────────────────────────────────
+
+    describe('pushStandardVersion', () => {
+        const standardJson = 'raw standard content';
+
+        it('returns id, version and location on 201', async () => {
+            mock.onPost('/calm/namespaces/finos/standards/20/versions/2.0.0').reply(201, null, {
+                location: '/calm/namespaces/finos/standards/20/versions/2.0.0'
+            });
+
+            const result = await client.pushStandardVersion('finos', 20, '2.0.0', 'my-standard', '', standardJson);
+            expect(result).toEqual({ id: 20, version: '2.0.0', location: '/calm/namespaces/finos/standards/20/versions/2.0.0' });
+        });
+
+        it('throws HubClientError(409) on duplicate version', async () => {
+            mock.onPost('/calm/namespaces/finos/standards/20/versions/1.0.0').reply(409, 'Version already exists');
+            await expect(client.pushStandardVersion('finos', 20, '1.0.0', 's', '', standardJson)).rejects.toMatchObject({ status: 409 });
+        });
+
+        it('throws HubClientError(404) when standard id not found', async () => {
+            mock.onPost('/calm/namespaces/finos/standards/99/versions/1.0.0').reply(404, 'Standard not found');
+            await expect(client.pushStandardVersion('finos', 99, '1.0.0', 's', '', standardJson)).rejects.toMatchObject({ status: 404 });
+        });
+    });
+
+    // ── listStandards ────────────────────────────────────────────────────────
+
+    describe('listStandards', () => {
+        it('fetches versions per standard and returns summaries', async () => {
+            mock.onGet('/calm/namespaces/finos/standards').reply(200, {
+                values: [
+                    { id: 1, name: 'standard-a', description: 'desc-a' },
+                    { id: 2, name: 'standard-b', description: '' }
+                ]
+            });
+            mock.onGet('/calm/namespaces/finos/standards/1/versions').reply(200, { values: ['1.0.0'] });
+            mock.onGet('/calm/namespaces/finos/standards/2/versions').reply(200, { values: ['1.0.0', '2.0.0'] });
+
+            const result = await client.listStandards('finos');
+            expect(result).toHaveLength(2);
+            expect(result[0]).toEqual({ id: 1, name: 'standard-a', description: 'desc-a', versions: ['1.0.0'] });
+            expect(result[1]).toEqual({ id: 2, name: 'standard-b', description: '', versions: ['1.0.0', '2.0.0'] });
+        });
+
+        it('returns empty array when no standards exist', async () => {
+            mock.onGet('/calm/namespaces/finos/standards').reply(200, { values: [] });
+            const result = await client.listStandards('finos');
+            expect(result).toEqual([]);
+        });
+
+        it('throws HubClientError(404) for unknown namespace', async () => {
+            mock.onGet('/calm/namespaces/unknown/standards').reply(404, 'Namespace not found');
+            await expect(client.listStandards('unknown')).rejects.toMatchObject({ status: 404 });
+        });
+    });
+
+    // ── pullStandard ─────────────────────────────────────────────────────────
+
+    describe('pullStandard', () => {
+        it('returns the standard detail object', async () => {
+            const detail = { id: 1, name: 'standard-a', version: '1.0.0', standardJson: 'raw' };
+            mock.onGet('/calm/namespaces/finos/standards/1/versions/1.0.0').reply(200, detail);
+
+            const result = await client.pullStandard('finos', 1, '1.0.0');
+            expect(result).toEqual(detail);
+        });
+
+        it('throws HubClientError(404) when not found', async () => {
+            mock.onGet('/calm/namespaces/finos/standards/99/versions/1.0.0').reply(404, 'Standard not found');
+            await expect(client.pullStandard('finos', 99, '1.0.0')).rejects.toMatchObject({ status: 404 });
+        });
+    });
+
+    // ── createDomain ─────────────────────────────────────────────────────────
+
+    describe('createDomain', () => {
+        it('returns name and location on 201', async () => {
+            mock.onPost('/calm/domains').reply(201, null, {});
+
+            const result = await client.createDomain('risk');
+            expect(result).toEqual({ name: 'risk', location: '/calm/domains/risk' });
+        });
+
+        it('throws HubClientError(409) on conflict', async () => {
+            mock.onPost('/calm/domains').reply(409, { error: 'Domain already exists' });
+
+            await expect(client.createDomain('risk')).rejects.toMatchObject({
+                status: 409,
+                error: 'Domain already exists',
+                request: 'POST /calm/domains'
+            });
+        });
+    });
+
+    // ── listDomains ──────────────────────────────────────────────────────────
+
+    describe('listDomains', () => {
+        it('returns array of domain summaries', async () => {
+            mock.onGet('/calm/domains').reply(200, {
+                values: [{ name: 'risk' }, { name: 'compliance' }]
+            });
+
+            const result = await client.listDomains();
+            expect(result).toHaveLength(2);
+            expect(result[0].name).toBe('risk');
+        });
+
+        it('returns empty array when values is absent', async () => {
+            mock.onGet('/calm/domains').reply(200, {});
+            const result = await client.listDomains();
+            expect(result).toEqual([]);
+        });
+    });
+
+    // ── createControl ─────────────────────────────────────────────────────────
+
+    describe('createControl', () => {
+        const reqJson = JSON.stringify({ type: 'control-requirement', requirements: [] });
+
+        it('returns id and location on 201', async () => {
+            mock.onPost('/calm/domains/risk/controls').reply(201, null, {
+                location: '/calm/domains/risk/controls/42'
+            });
+
+            const result = await client.createControl('risk', 'my-control', 'A control', reqJson);
+            expect(result).toEqual({ id: 42, location: '/calm/domains/risk/controls/42' });
+        });
+
+        it('sends correct body fields including requirementJson', async () => {
+            let capturedBody: unknown;
+            mock.onPost('/calm/domains/risk/controls').reply((config) => {
+                capturedBody = JSON.parse(config.data as string);
+                return [201, null, { location: '/calm/domains/risk/controls/1' }];
+            });
+
+            await client.createControl('risk', 'my-control', 'A control', reqJson);
+            expect(capturedBody).toMatchObject({ name: 'my-control', description: 'A control', requirementJson: reqJson });
+        });
+
+        it('throws HubClientError(409) on conflict', async () => {
+            mock.onPost('/calm/domains/risk/controls').reply(409, { error: 'Control already exists' });
+
+            await expect(client.createControl('risk', 'dup', 'desc', reqJson)).rejects.toMatchObject({
+                status: 409,
+                request: 'POST /calm/domains/risk/controls'
+            });
+        });
+    });
+
+    // ── listControls ──────────────────────────────────────────────────────────
+
+    describe('listControls', () => {
+        it('returns array of control summaries', async () => {
+            mock.onGet('/calm/domains/risk/controls').reply(200, {
+                values: [
+                    { id: 1, name: 'control-a' },
+                    { id: 2, name: 'control-b' }
+                ]
+            });
+
+            const result = await client.listControls('risk');
+            expect(result).toHaveLength(2);
+            expect(result[0]).toEqual({ id: 1, name: 'control-a' });
+        });
+
+        it('returns empty array when values is absent', async () => {
+            mock.onGet('/calm/domains/risk/controls').reply(200, {});
+            const result = await client.listControls('risk');
+            expect(result).toEqual([]);
+        });
+    });
+
+    // ── pushControlRequirement ────────────────────────────────────────────────
+
+    describe('pushControlRequirement', () => {
+        const reqName = 'access-control';
+        const reqDescription = 'Access control requirement wrapper';
+        const reqJson = JSON.stringify({ type: 'control-requirement', requirements: [] });
+
+        it('returns id, version and location on 201 with Location header', async () => {
+            mock.onPost('/calm/domains/risk/controls/1/requirement/versions/1.0.0').reply(201, null, {
+                location: '/calm/domains/risk/controls/1/requirement/versions/1.0.0'
+            });
+
+            const result = await client.pushControlRequirement('risk', 1, '1.0.0', reqName, reqDescription, reqJson);
+            expect(result).toEqual({
+                id: 1,
+                version: '1.0.0',
+                location: '/calm/domains/risk/controls/1/requirement/versions/1.0.0'
+            });
+        });
+
+        it('returns constructed location when header is absent', async () => {
+            mock.onPost('/calm/domains/risk/controls/1/requirement/versions/1.0.0').reply(201, null, {});
+
+            const result = await client.pushControlRequirement('risk', 1, '1.0.0', reqName, reqDescription, reqJson);
+            expect(result.location).toBe('/calm/domains/risk/controls/1/requirement/versions/1.0.0');
+        });
+
+        it('sends wrapper payload with name, description and requirementJson', async () => {
+            mock.onPost('/calm/domains/risk/controls/1/requirement/versions/1.0.0').reply(201, null, {
+                location: '/calm/domains/risk/controls/1/requirement/versions/1.0.0'
+            });
+
+            await client.pushControlRequirement('risk', 1, '1.0.0', reqName, reqDescription, reqJson);
+
+            expect(mock.history.post).toHaveLength(1);
+            expect(JSON.parse(mock.history.post[0].data as string)).toEqual({
+                name: reqName,
+                description: reqDescription,
+                requirementJson: reqJson
+            });
+        });
+
+        it('throws HubClientError(400) on bad request', async () => {
+            mock.onPost('/calm/domains/risk/controls/1/requirement/versions/1.0.0').reply(400, 'Bad request');
+            await expect(client.pushControlRequirement('risk', 1, '1.0.0', reqName, reqDescription, reqJson)).rejects.toMatchObject({
+                status: 400,
+                request: 'POST /calm/domains/risk/controls/1/requirement/versions/1.0.0'
+            });
+        });
+    });
+
+    // ── pullControlRequirement ────────────────────────────────────────────────
+
+    describe('pullControlRequirement', () => {
+        it('returns the requirement detail object', async () => {
+            const detail = { type: 'control-requirement', requirements: [] };
+            mock.onGet('/calm/domains/risk/controls/1/requirement/versions/1.0.0').reply(200, detail);
+
+            const result = await client.pullControlRequirement('risk', 1, '1.0.0');
+            expect(result).toEqual(detail);
+        });
+
+        it('throws HubClientError(404) when not found', async () => {
+            mock.onGet('/calm/domains/risk/controls/99/requirement/versions/1.0.0').reply(404, 'Not found');
+            await expect(client.pullControlRequirement('risk', 99, '1.0.0')).rejects.toMatchObject({ status: 404 });
+        });
+    });
+
+    // ── pushControlConfiguration ─────────────────────────────────────────────
+
+    describe('pushControlConfiguration', () => {
+        const configJson = JSON.stringify({ type: 'control-configuration', config: {} });
+
+        it('returns id, version and location on 201 with Location header', async () => {
+            mock.onPost('/calm/domains/risk/controls/1/configurations/5/versions/1.0.0').reply(201, null, {
+                location: '/calm/domains/risk/controls/1/configurations/5/versions/1.0.0'
+            });
+
+            const result = await client.pushControlConfiguration('risk', 1, 5, '1.0.0', configJson);
+            expect(result).toEqual({
+                id: 5,
+                version: '1.0.0',
+                location: '/calm/domains/risk/controls/1/configurations/5/versions/1.0.0'
+            });
+        });
+
+        it('returns constructed location when header is absent', async () => {
+            mock.onPost('/calm/domains/risk/controls/1/configurations/5/versions/1.0.0').reply(201, null, {});
+
+            const result = await client.pushControlConfiguration('risk', 1, 5, '1.0.0', configJson);
+            expect(result.location).toBe('/calm/domains/risk/controls/1/configurations/5/versions/1.0.0');
+        });
+
+        it('sends wrapper payload with configurationJson', async () => {
+            mock.onPost('/calm/domains/risk/controls/1/configurations/5/versions/1.0.0').reply(201, null, {
+                location: '/calm/domains/risk/controls/1/configurations/5/versions/1.0.0'
+            });
+
+            await client.pushControlConfiguration('risk', 1, 5, '1.0.0', configJson);
+
+            expect(mock.history.post).toHaveLength(1);
+            expect(JSON.parse(mock.history.post[0].data as string)).toEqual({
+                configurationJson: configJson
+            });
+        });
+
+        it('throws HubClientError(400) on bad request', async () => {
+            mock.onPost('/calm/domains/risk/controls/1/configurations/5/versions/1.0.0').reply(400, 'Bad request');
+            await expect(client.pushControlConfiguration('risk', 1, 5, '1.0.0', configJson)).rejects.toMatchObject({
+                status: 400,
+                request: 'POST /calm/domains/risk/controls/1/configurations/5/versions/1.0.0'
+            });
+        });
+    });
+
+    // ── pullControlConfiguration ─────────────────────────────────────────────
+
+    describe('pullControlConfiguration', () => {
+        it('returns the config detail object', async () => {
+            const detail = { type: 'control-configuration', config: {} };
+            mock.onGet('/calm/domains/risk/controls/1/configurations/5/versions/1.0.0').reply(200, detail);
+
+            const result = await client.pullControlConfiguration('risk', 1, 5, '1.0.0');
+            expect(result).toEqual(detail);
+        });
+
+        it('throws HubClientError(404) when not found', async () => {
+            mock.onGet('/calm/domains/risk/controls/99/configurations/5/versions/1.0.0').reply(404, 'Not found');
+            await expect(client.pullControlConfiguration('risk', 99, 5, '1.0.0')).rejects.toMatchObject({ status: 404 });
+        });
+    });
+
+    // ── createControlConfiguration ────────────────────────────────────────────
+
+    describe('createControlConfiguration', () => {
+        const configJson = JSON.stringify({ type: 'control-configuration', config: {} });
+
+        it('returns id and location on 201 with Location header', async () => {
+            mock.onPost('/calm/domains/risk/controls/1/configurations').reply(201, null, {
+                location: '/calm/domains/risk/controls/1/configurations/5'
+            });
+
+            const result = await client.createControlConfiguration('risk', 1, configJson);
+            expect(result).toEqual({
+                id: 5,
+                location: '/calm/domains/risk/controls/1/configurations/5'
+            });
+        });
+
+        it('throws HubClientError(404) when control not found', async () => {
+            mock.onPost('/calm/domains/risk/controls/99/configurations').reply(404, 'Not found');
+            await expect(client.createControlConfiguration('risk', 99, configJson)).rejects.toMatchObject({ status: 404 });
+        });
+    });
+
+    // ── listControlConfigurations ─────────────────────────────────────────────
+
+    describe('listControlConfigurations', () => {
+        it('returns list of config IDs', async () => {
+            mock.onGet('/calm/domains/risk/controls/1/configurations').reply(200, { values: [1, 2, 3] });
+
+            const result = await client.listControlConfigurations('risk', 1);
+            expect(result).toEqual([1, 2, 3]);
+        });
+
+        it('returns empty array when no configurations', async () => {
+            mock.onGet('/calm/domains/risk/controls/1/configurations').reply(200, { values: [] });
+
+            const result = await client.listControlConfigurations('risk', 1);
+            expect(result).toEqual([]);
+        });
+
+        it('throws HubClientError(404) when control not found', async () => {
+            mock.onGet('/calm/domains/risk/controls/99/configurations').reply(404, 'Not found');
+            await expect(client.listControlConfigurations('risk', 99)).rejects.toMatchObject({ status: 404 });
+        });
+    });
+
+    // ── listControlRequirementVersions ────────────────────────────────────────
+
+    describe('listControlRequirementVersions', () => {
+        it('returns list of version strings', async () => {
+            mock.onGet('/calm/domains/risk/controls/1/requirement/versions').reply(200, { values: ['1.0.0', '2.0.0'] });
+
+            const result = await client.listControlRequirementVersions('risk', 1);
+            expect(result).toEqual(['1.0.0', '2.0.0']);
+        });
+
+        it('returns empty array when no versions', async () => {
+            mock.onGet('/calm/domains/risk/controls/1/requirement/versions').reply(200, { values: [] });
+
+            const result = await client.listControlRequirementVersions('risk', 1);
+            expect(result).toEqual([]);
+        });
+
+        it('throws HubClientError(404) when control not found', async () => {
+            mock.onGet('/calm/domains/risk/controls/99/requirement/versions').reply(404, 'Not found');
+            await expect(client.listControlRequirementVersions('risk', 99)).rejects.toMatchObject({ status: 404 });
+        });
+    });
+
+    // ── listControlRequirements ───────────────────────────────────────────────
+
+    describe('listControlRequirements', () => {
+        it('returns control requirements with versions', async () => {
+            mock.onGet('/calm/domains/risk/controls').reply(200, {
+                values: [
+                    { id: 20, name: 'Encryption At Rest Requirement Updated', description: 'Updated control for encryption at rest' },
+                    { id: 21, name: 'Data Retention Requirement', description: 'Control for data retention' }
+                ]
+            });
+            mock.onGet('/calm/domains/risk/controls/20/requirement/versions').reply(200, { values: ['1.0.0'] });
+            mock.onGet('/calm/domains/risk/controls/21/requirement/versions').reply(200, { values: ['1.0.0', '2.0.0'] });
+
+            const result = await client.listControlRequirements('risk');
+
+            expect(result).toEqual([
+                {
+                    'control-id': 20,
+                    name: 'Encryption At Rest Requirement Updated',
+                    description: 'Updated control for encryption at rest',
+                    versions: ['1.0.0']
+                },
+                {
+                    'control-id': 21,
+                    name: 'Data Retention Requirement',
+                    description: 'Control for data retention',
+                    versions: ['1.0.0', '2.0.0']
+                }
+            ]);
+        });
+
+        it('returns empty array when no controls exist', async () => {
+            mock.onGet('/calm/domains/risk/controls').reply(200, { values: [] });
+
+            const result = await client.listControlRequirements('risk');
+
+            expect(result).toEqual([]);
+        });
+
+        it('includes controls with empty version lists', async () => {
+            mock.onGet('/calm/domains/risk/controls').reply(200, {
+                values: [{ id: 22, name: 'Logging Requirement', description: 'Control for logging' }]
+            });
+            mock.onGet('/calm/domains/risk/controls/22/requirement/versions').reply(200, { values: [] });
+
+            const result = await client.listControlRequirements('risk');
+
+            expect(result).toEqual([
+                {
+                    'control-id': 22,
+                    name: 'Logging Requirement',
+                    description: 'Control for logging',
+                    versions: []
+                }
+            ]);
+        });
+
+        it('fails when listing controls fails', async () => {
+            mock.onGet('/calm/domains/risk/controls').reply(500, { error: 'Internal server error' });
+
+            await expect(client.listControlRequirements('risk')).rejects.toMatchObject({
+                status: 500,
+                request: 'GET /calm/domains/risk/controls'
+            });
+        });
+
+        it('fails when one control version lookup fails', async () => {
+            mock.onGet('/calm/domains/risk/controls').reply(200, {
+                values: [
+                    { id: 20, name: 'Encryption At Rest Requirement Updated', description: 'Updated control for encryption at rest' },
+                    { id: 21, name: 'Data Retention Requirement', description: 'Control for data retention' }
+                ]
+            });
+            mock.onGet('/calm/domains/risk/controls/20/requirement/versions').reply(200, { values: ['1.0.0'] });
+            mock.onGet('/calm/domains/risk/controls/21/requirement/versions').reply(404, 'Not found');
+
+            await expect(client.listControlRequirements('risk')).rejects.toMatchObject({
+                status: 404,
+                request: 'GET /calm/domains/risk/controls/21/requirement/versions'
+            });
+        });
+    });
+
+    // ── listControlConfigurationVersions ─────────────────────────────────────
+
+    describe('listControlConfigurationVersions', () => {
+        it('returns list of version strings', async () => {
+            mock.onGet('/calm/domains/risk/controls/1/configurations/5/versions').reply(200, { values: ['1.0.0', '2.0.0'] });
+
+            const result = await client.listControlConfigurationVersions('risk', 1, 5);
+            expect(result).toEqual(['1.0.0', '2.0.0']);
+        });
+
+        it('returns empty array when no versions', async () => {
+            mock.onGet('/calm/domains/risk/controls/1/configurations/5/versions').reply(200, { values: [] });
+
+            const result = await client.listControlConfigurationVersions('risk', 1, 5);
+            expect(result).toEqual([]);
+        });
+
+        it('throws HubClientError(404) when configuration not found', async () => {
+            mock.onGet('/calm/domains/risk/controls/1/configurations/99/versions').reply(404, 'Not found');
+            await expect(client.listControlConfigurationVersions('risk', 1, 99)).rejects.toMatchObject({ status: 404 });
+        });
+    });
+
+    // ── auth plugin: domains/controls ─────────────────────────────────────────
+
+    describe('auth plugin: domains/controls', () => {
+        let authMock: AxiosMockAdapter;
+        let authClient: CalmHubClient;
+        let getAuthHeaders: ReturnType<typeof vi.fn>;
+
+        beforeEach(() => {
+            getAuthHeaders = vi.fn().mockResolvedValue({ Authorization: 'Bearer test-token' });
+            const authPlugin = { getAuthHeaders };
+            const ax = axios.create({ baseURL: 'http://localhost:8080' });
+            authMock = new AxiosMockAdapter(ax);
+            authClient = new CalmHubClient({ calmHubUrl: 'http://localhost:8080', authPlugin }, ax);
+        });
+
+        it('injects auth headers on createDomain', async () => {
+            authMock.onPost('/calm/domains').reply(201, null, {});
+
+            await authClient.createDomain('risk');
+            expect(getAuthHeaders).toHaveBeenCalled();
+        });
+
+        it('injects auth headers on listDomains', async () => {
+            authMock.onGet('/calm/domains').reply(200, { values: [] });
+
+            await authClient.listDomains();
+            expect(getAuthHeaders).toHaveBeenCalled();
+        });
+
+        it('injects auth headers on pushControlRequirement', async () => {
+            authMock.onPost('/calm/domains/risk/controls/1/requirement/versions/1.0.0').reply(201, null, {
+                location: '/calm/domains/risk/controls/1/requirement/versions/1.0.0'
+            });
+
+            await authClient.pushControlRequirement('risk', 1, '1.0.0', 'req-name', 'req-description', '{}');
+            expect(getAuthHeaders).toHaveBeenCalled();
+        });
+
+        it('injects auth headers on pullControlConfiguration', async () => {
+            authMock.onGet('/calm/domains/risk/controls/1/configurations/5/versions/1.0.0').reply(200, {});
+
+            await authClient.pullControlConfiguration('risk', 1, 5, '1.0.0');
+            expect(getAuthHeaders).toHaveBeenCalled();
+        });
+    });
 });

--- a/shared/src/hub/calm-hub-client.ts
+++ b/shared/src/hub/calm-hub-client.ts
@@ -18,6 +18,20 @@ export interface HubArchitectureSummary {
     versions: string[];
 }
 
+export interface HubPatternSummary {
+    id: number;
+    name: string;
+    description?: string;
+    versions: string[];
+}
+
+export interface HubStandardSummary {
+    id: number;
+    name: string;
+    description?: string;
+    versions: string[];
+}
+
 export interface HubCreateResult {
     id: number;
     version?: string;
@@ -29,7 +43,35 @@ export interface HubNamespaceCreateResult {
     location: string;
 }
 
+export interface HubDomainCreateResult {
+    name: string;
+    location: string;
+}
+
+export interface HubDomainSummary {
+    name: string;
+}
+
+export interface HubControlSummary {
+    id: number;
+    name: string;
+    description?: string;
+}
+
+export interface HubControlRequirementSummary {
+    'control-id': number;
+    name: string;
+    description?: string;
+    versions: string[];
+}
+
 export class HubClientError extends Error {
+    /**
+     * Creates a normalized Hub client error.
+     * @param status HTTP status code or 0 for non-HTTP failures.
+     * @param error Error message.
+     * @param request Request label that failed.
+     */
     constructor(
         public readonly status: number,
         public readonly error: string,
@@ -43,6 +85,11 @@ export class HubClientError extends Error {
 export class CalmHubClient {
     private readonly ax: Axios;
 
+    /**
+     * Creates a Hub client bound to a base URL and optional auth plugin.
+     * @param options Hub connection options.
+     * @param axiosInstance Optional injected axios instance for testing.
+     */
     constructor(options: CalmHubOptions, axiosInstance?: Axios) {
         const baseUrl = options.calmHubUrl;
        
@@ -70,6 +117,12 @@ export class CalmHubClient {
 
     // ── Namespaces ───────────────────────────────────────────────────────────
 
+    /**
+     * Creates a namespace.
+     * @param name Namespace name.
+     * @param description Namespace description.
+     * @returns Created namespace result with location.
+     */
     async createNamespace(name: string, description: string): Promise<HubNamespaceCreateResult> {
         const endpoint = 'POST /calm/namespaces';
         try {
@@ -81,6 +134,10 @@ export class CalmHubClient {
         }
     }
 
+    /**
+     * Lists namespaces.
+     * @returns Namespace summaries.
+     */
     async listNamespaces(): Promise<HubNamespaceSummary[]> {
         const endpoint = 'GET /calm/namespaces';
         try {
@@ -94,6 +151,14 @@ export class CalmHubClient {
 
     // ── Architectures ────────────────────────────────────────────────────────
 
+    /**
+     * Creates a new architecture.
+     * @param namespace Namespace name.
+     * @param name Architecture name.
+     * @param description Architecture description.
+     * @param architectureJson Architecture JSON payload.
+     * @returns Created resource metadata.
+     */
     async pushArchitecture(
         namespace: string,
         name: string,
@@ -114,6 +179,16 @@ export class CalmHubClient {
         }
     }
 
+    /**
+     * Creates a new version for an existing architecture.
+     * @param namespace Namespace name.
+     * @param id Architecture id.
+     * @param version Version label.
+     * @param name Architecture name.
+     * @param description Architecture description.
+     * @param architectureJson Architecture JSON payload.
+     * @returns Created resource metadata.
+     */
     async pushArchitectureVersion(
         namespace: string,
         id: number,
@@ -135,6 +210,11 @@ export class CalmHubClient {
         }
     }
 
+    /**
+     * Lists architectures and their versions in a namespace.
+     * @param namespace Namespace name.
+     * @returns Architecture summaries.
+     */
     async listArchitectures(namespace: string): Promise<HubArchitectureSummary[]> {
         const endpoint = `GET /calm/namespaces/${namespace}/architectures`;
         try {
@@ -162,6 +242,13 @@ export class CalmHubClient {
         }
     }
 
+    /**
+     * Pulls a specific architecture version.
+     * @param namespace Namespace name.
+     * @param id Architecture id.
+     * @param version Version label.
+     * @returns Architecture document.
+     */
     async pullArchitecture(namespace: string, id: number, version: string): Promise<object> {
         const endpoint = `GET /calm/namespaces/${namespace}/architectures/${id}/versions/${version}`;
         try {
@@ -169,6 +256,503 @@ export class CalmHubClient {
                 `/calm/namespaces/${namespace}/architectures/${id}/versions/${version}`
             );
             return response.data as object;
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    // ── Patterns ─────────────────────────────────────────────────────────────
+
+    /**
+     * Creates a new pattern.
+     * @param namespace Namespace name.
+     * @param name Pattern name.
+     * @param description Pattern description.
+     * @param patternJson Pattern JSON payload.
+     * @returns Created resource metadata.
+     */
+    async pushPattern(
+        namespace: string,
+        name: string,
+        description: string,
+        patternJson: string
+    ): Promise<HubCreateResult> {
+        const endpoint = `POST /calm/namespaces/${namespace}/patterns`;
+        try {
+            const response = await this.ax.post(`/calm/namespaces/${namespace}/patterns`, {
+                name,
+                description,
+                patternJson
+            });
+            const location = response.headers['location'] as string;
+            return this.parseVersionedLocation(location, endpoint);
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Creates a new version for an existing pattern.
+     * @param namespace Namespace name.
+     * @param id Pattern id.
+     * @param version Version label.
+     * @param name Pattern name.
+     * @param description Pattern description.
+     * @param patternJson Pattern JSON payload.
+     * @returns Created resource metadata.
+     */
+    async pushPatternVersion(
+        namespace: string,
+        id: number,
+        version: string,
+        name: string,
+        description: string,
+        patternJson: string
+    ): Promise<HubCreateResult> {
+        const endpoint = `POST /calm/namespaces/${namespace}/patterns/${id}/versions/${version}`;
+        try {
+            const response = await this.ax.post(
+                `/calm/namespaces/${namespace}/patterns/${id}/versions/${version}`,
+                { name, description, patternJson }
+            );
+            const location = response.headers['location'] as string;
+            return this.parseVersionedLocation(location, endpoint);
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Lists patterns and their versions in a namespace.
+     * @param namespace Namespace name.
+     * @returns Pattern summaries.
+     */
+    async listPatterns(namespace: string): Promise<HubPatternSummary[]> {
+        const endpoint = `GET /calm/namespaces/${namespace}/patterns`;
+        try {
+            const response = await this.ax.get(`/calm/namespaces/${namespace}/patterns`);
+            const items: { id: number; name: string; description?: string }[] =
+                response.data?.values ?? [];
+            const summaries = await Promise.all(
+                items.map(async (item) => {
+                    const versionsEndpoint = `GET /calm/namespaces/${namespace}/patterns/${item.id}/versions`;
+                    try {
+                        const vRes = await this.ax.get(
+                            `/calm/namespaces/${namespace}/patterns/${item.id}/versions`
+                        );
+                        const versions: string[] = vRes.data?.values ?? [];
+                        return { id: item.id, name: item.name, description: item.description, versions };
+                    } catch (err) {
+                        throw this.wrapError(err, versionsEndpoint);
+                    }
+                })
+            );
+            return summaries;
+        } catch (err) {
+            if (err instanceof HubClientError) throw err;
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Pulls a specific pattern version.
+     * @param namespace Namespace name.
+     * @param id Pattern id.
+     * @param version Version label.
+     * @returns Pattern document.
+     */
+    async pullPattern(namespace: string, id: number, version: string): Promise<object> {
+        const endpoint = `GET /calm/namespaces/${namespace}/patterns/${id}/versions/${version}`;
+        try {
+            const response = await this.ax.get(
+                `/calm/namespaces/${namespace}/patterns/${id}/versions/${version}`
+            );
+            return response.data as object;
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    // ── Standards ─────────────────────────────────────────────────────────────
+
+    /**
+     * Creates a new standard.
+     * @param namespace Namespace name.
+     * @param name Standard name.
+     * @param description Standard description.
+     * @param standardJson Standard JSON payload.
+     * @returns Created resource metadata.
+     */
+    async pushStandard(
+        namespace: string,
+        name: string,
+        description: string,
+        standardJson: string
+    ): Promise<HubCreateResult> {
+        const endpoint = `POST /calm/namespaces/${namespace}/standards`;
+        try {
+            const response = await this.ax.post(`/calm/namespaces/${namespace}/standards`, {
+                name,
+                description,
+                standardJson
+            });
+            const location = response.headers['location'] as string;
+            return this.parseVersionedLocation(location, endpoint);
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Creates a new version for an existing standard.
+     * @param namespace Namespace name.
+     * @param id Standard id.
+     * @param version Version label.
+     * @param name Standard name.
+     * @param description Standard description.
+     * @param standardJson Standard JSON payload.
+     * @returns Created resource metadata.
+     */
+    async pushStandardVersion(
+        namespace: string,
+        id: number,
+        version: string,
+        name: string,
+        description: string,
+        standardJson: string
+    ): Promise<HubCreateResult> {
+        const endpoint = `POST /calm/namespaces/${namespace}/standards/${id}/versions/${version}`;
+        try {
+            const response = await this.ax.post(
+                `/calm/namespaces/${namespace}/standards/${id}/versions/${version}`,
+                { name, description, standardJson }
+            );
+            const location = response.headers['location'] as string;
+            return this.parseVersionedLocation(location, endpoint);
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Lists standards and their versions in a namespace.
+     * @param namespace Namespace name.
+     * @returns Standard summaries.
+     */
+    async listStandards(namespace: string): Promise<HubStandardSummary[]> {
+        const endpoint = `GET /calm/namespaces/${namespace}/standards`;
+        try {
+            const response = await this.ax.get(`/calm/namespaces/${namespace}/standards`);
+            const items: { id: number; name: string; description?: string }[] =
+                response.data?.values ?? [];
+            const summaries = await Promise.all(
+                items.map(async (item) => {
+                    const versionsEndpoint = `GET /calm/namespaces/${namespace}/standards/${item.id}/versions`;
+                    try {
+                        const vRes = await this.ax.get(
+                            `/calm/namespaces/${namespace}/standards/${item.id}/versions`
+                        );
+                        const versions: string[] = vRes.data?.values ?? [];
+                        return { id: item.id, name: item.name, description: item.description, versions };
+                    } catch (err) {
+                        throw this.wrapError(err, versionsEndpoint);
+                    }
+                })
+            );
+            return summaries;
+        } catch (err) {
+            if (err instanceof HubClientError) throw err;
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Pulls a specific standard version.
+     * @param namespace Namespace name.
+     * @param id Standard id.
+     * @param version Version label.
+     * @returns Standard document.
+     */
+    async pullStandard(namespace: string, id: number, version: string): Promise<object> {
+        const endpoint = `GET /calm/namespaces/${namespace}/standards/${id}/versions/${version}`;
+        try {
+            const response = await this.ax.get(
+                `/calm/namespaces/${namespace}/standards/${id}/versions/${version}`
+            );
+            return response.data as object;
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    // ── Domains/Controls ─────────────────────────────────────────────────────
+
+    /**
+     * Creates a domain.
+     * @param name Domain name.
+     * @returns Created domain metadata.
+     */
+    async createDomain(name: string): Promise<HubDomainCreateResult> {
+        const endpoint = 'POST /calm/domains';
+        try {
+            await this.ax.post('/calm/domains', { name });
+            return { name, location: `/calm/domains/${name}` };
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Lists domains.
+     * @returns Domain summaries.
+     */
+    async listDomains(): Promise<HubDomainSummary[]> {
+        const endpoint = 'GET /calm/domains';
+        try {
+            const response = await this.ax.get('/calm/domains');
+            const values: HubDomainSummary[] = response.data?.values ?? [];
+            return values;
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Creates a control requirement.
+     * @param domain Domain name.
+     * @param name Control name.
+     * @param description Control description.
+     * @param requirementJson Requirement JSON payload.
+     * @returns Created resource metadata.
+     */
+    async createControl(domain: string, name: string, description: string, requirementJson: string): Promise<HubCreateResult> {
+        const endpoint = `POST /calm/domains/${domain}/controls`;
+        try {
+            const response = await this.ax.post(`/calm/domains/${domain}/controls`, { name, description, requirementJson });
+            const location = (response.headers['location'] as string | undefined) ?? `/calm/domains/${domain}/controls`;
+            const id = this.parseIdFromLocation(location, endpoint);
+            return { id, location };
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Lists controls for a domain.
+     * @param domain Domain name.
+     * @returns Control summaries.
+     */
+    async listControls(domain: string): Promise<HubControlSummary[]> {
+        const endpoint = `GET /calm/domains/${domain}/controls`;
+        try {
+            const response = await this.ax.get(`/calm/domains/${domain}/controls`);
+            const values: HubControlSummary[] = response.data?.values ?? [];
+            return values;
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Lists control requirements and their versions for a domain.
+     * @param domain Domain name.
+     * @returns Control requirement summaries.
+     */
+    async listControlRequirements(domain: string): Promise<HubControlRequirementSummary[]> {
+        const endpoint = `GET /calm/domains/${domain}/controls`;
+        try {
+            const controls = await this.listControls(domain);
+            const summaries = await Promise.all(
+                controls.map(async (control) => {
+                    const versionsEndpoint = `GET /calm/domains/${domain}/controls/${control.id}/requirement/versions`;
+                    try {
+                        const versions = await this.listControlRequirementVersions(domain, control.id);
+                        return {
+                            'control-id': control.id,
+                            name: control.name,
+                            description: control.description,
+                            versions
+                        };
+                    } catch (err) {
+                        throw this.wrapError(err, versionsEndpoint);
+                    }
+                })
+            );
+            return summaries;
+        } catch (err) {
+            if (err instanceof HubClientError) throw err;
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Pushes a versioned control requirement.
+     * @param domain Domain name.
+     * @param controlId Control id.
+     * @param version Version label.
+     * @param name Requirement wrapper name.
+     * @param description Requirement wrapper description.
+     * @param requirementJson Requirement JSON payload.
+     * @returns Created resource metadata.
+     */
+    async pushControlRequirement(
+        domain: string,
+        controlId: number,
+        version: string,
+        name: string,
+        description: string,
+        requirementJson: string
+    ): Promise<HubCreateResult> {
+        const endpoint = `POST /calm/domains/${domain}/controls/${controlId}/requirement/versions/${version}`;
+        // print debug all parameters except requirementJson which may be large
+        console.debug(`pushControlRequirement called with domain=${domain}, controlId=${controlId}, version=${version}, name=${name}, description=${description}`);
+        // print debug first 200 characters of requirementJson
+        console.debug(`requirementJson: ${requirementJson.substring(0, 200)}${requirementJson.length > 200 ? '... (truncated)' : ''}`);
+        try {
+            const response = await this.ax.post(
+                `/calm/domains/${domain}/controls/${controlId}/requirement/versions/${version}`,
+                { name, description, requirementJson },
+                { headers: { 'Content-Type': 'application/json' } }
+            );
+            const location = (response.headers['location'] as string | undefined)
+                ?? `/calm/domains/${domain}/controls/${controlId}/requirement/versions/${version}`;
+            return { id: controlId, version, location };
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Pulls a versioned control requirement.
+     * @param domain Domain name.
+     * @param controlId Control id.
+     * @param version Version label.
+     * @returns Requirement document.
+     */
+    async pullControlRequirement(domain: string, controlId: number, version: string): Promise<object> {
+        const endpoint = `GET /calm/domains/${domain}/controls/${controlId}/requirement/versions/${version}`;
+        try {
+            const response = await this.ax.get(
+                `/calm/domains/${domain}/controls/${controlId}/requirement/versions/${version}`
+            );
+            return response.data as object;
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Pushes a versioned control configuration.
+     * @param domain Domain name.
+     * @param controlId Control id.
+     * @param configId Configuration id.
+     * @param version Version label.
+     * @param configJson Configuration JSON payload.
+     * @returns Created resource metadata.
+     */
+    async pushControlConfiguration(domain: string, controlId: number, configId: number, version: string, configJson: string): Promise<HubCreateResult> {
+        const endpoint = `POST /calm/domains/${domain}/controls/${controlId}/configurations/${configId}/versions/${version}`;
+        try {
+            const response = await this.ax.post(
+                `/calm/domains/${domain}/controls/${controlId}/configurations/${configId}/versions/${version}`,
+                { configurationJson: configJson },
+                { headers: { 'Content-Type': 'application/json' } }
+            );
+            const location = (response.headers['location'] as string | undefined)
+                ?? `/calm/domains/${domain}/controls/${controlId}/configurations/${configId}/versions/${version}`;
+            return { id: configId, version, location };
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Pulls a versioned control configuration.
+     * @param domain Domain name.
+     * @param controlId Control id.
+     * @param configId Configuration id.
+     * @param version Version label.
+     * @returns Configuration document.
+     */
+    async pullControlConfiguration(domain: string, controlId: number, configId: number, version: string): Promise<object> {
+        const endpoint = `GET /calm/domains/${domain}/controls/${controlId}/configurations/${configId}/versions/${version}`;
+        try {
+            const response = await this.ax.get(
+                `/calm/domains/${domain}/controls/${controlId}/configurations/${configId}/versions/${version}`
+            );
+            return response.data as object;
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Creates a control configuration.
+     * @param domain Domain name.
+     * @param controlId Control id.
+     * @param configurationJson Configuration JSON payload.
+     * @returns Created resource metadata.
+     */
+    async createControlConfiguration(domain: string, controlId: number, configurationJson: string): Promise<HubCreateResult> {
+        const endpoint = `POST /calm/domains/${domain}/controls/${controlId}/configurations`;
+        try {
+            const response = await this.ax.post(
+                `/calm/domains/${domain}/controls/${controlId}/configurations`,
+                { configurationJson }
+            );
+            const location = (response.headers['location'] as string | undefined)
+                ?? `/calm/domains/${domain}/controls/${controlId}/configurations`;
+            const id = this.parseIdFromLocation(location, endpoint);
+            return { id, location };
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Lists control configuration ids for a control.
+     * @param domain Domain name.
+     * @param controlId Control id.
+     * @returns Configuration ids.
+     */
+    async listControlConfigurations(domain: string, controlId: number): Promise<number[]> {
+        const endpoint = `GET /calm/domains/${domain}/controls/${controlId}/configurations`;
+        try {
+            const response = await this.ax.get(`/calm/domains/${domain}/controls/${controlId}/configurations`);
+            return (response.data?.values ?? []) as number[];
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Lists control requirement versions.
+     * @param domain Domain name.
+     * @param controlId Control id.
+     * @returns Requirement versions.
+     */
+    async listControlRequirementVersions(domain: string, controlId: number): Promise<string[]> {
+        const endpoint = `GET /calm/domains/${domain}/controls/${controlId}/requirement/versions`;
+        try {
+            const response = await this.ax.get(`/calm/domains/${domain}/controls/${controlId}/requirement/versions`);
+            return (response.data?.values ?? []) as string[];
+        } catch (err) {
+            throw this.wrapError(err, endpoint);
+        }
+    }
+
+    /**
+     * Lists control configuration versions.
+     * @param domain Domain name.
+     * @param controlId Control id.
+     * @param configId Configuration id.
+     * @returns Configuration versions.
+     */
+    async listControlConfigurationVersions(domain: string, controlId: number, configId: number): Promise<string[]> {
+        const endpoint = `GET /calm/domains/${domain}/controls/${controlId}/configurations/${configId}/versions`;
+        try {
+            const response = await this.ax.get(`/calm/domains/${domain}/controls/${controlId}/configurations/${configId}/versions`);
+            return (response.data?.values ?? []) as string[];
         } catch (err) {
             throw this.wrapError(err, endpoint);
         }
@@ -192,7 +776,24 @@ export class CalmHubClient {
         };
     }
 
+    /**
+     * Parses a resource id from a Location header of the form
+     * /calm/.../{id} or /calm/.../{id}/
+     */
+    private parseIdFromLocation(location: string, endpoint: string): number {
+        const match = /\/(\d+)\/?$/.exec(location);
+        if (!match) {
+            throw new HubClientError(0, `Could not parse location header: ${location}`, endpoint);
+        }
+        return parseInt(match[1], 10);
+    }
 
+    /**
+     * Converts unknown errors into HubClientError with endpoint context.
+     * @param err Unknown thrown value.
+     * @param endpoint Endpoint label.
+     * @returns Normalized Hub client error.
+     */
     private wrapError(err: unknown, endpoint: string): HubClientError {
         if (err instanceof HubClientError) return err;
         if (axios.isAxiosError(err) && err.response) {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -66,8 +66,14 @@ export {
     HubClientError,
     type HubNamespaceSummary,
     type HubArchitectureSummary,
+    type HubPatternSummary,
+    type HubStandardSummary,
     type HubCreateResult,
     type HubNamespaceCreateResult,
+    type HubDomainCreateResult,
+    type HubDomainSummary,
+    type HubControlSummary,
+    type HubControlRequirementSummary,
     type CalmHubOptions
 } from './hub/calm-hub-client.js';
 export {


### PR DESCRIPTION
## Description

Latest merge with `upstream/main`.
---

**NOTE**: I was able to recreate the Github Action errors locally by running `npm ci`.  Based on this, I think this is a time I need to commit `package-lock.json`.  After I ran `npm install` which modified `package-lock.json`, `npm ci` **did not fail** locally.  Given this, I committed the `package-lock.json` to the branch and pushed it up.

If you think this was a mistake, let me know and we can discuss a better solution.

---
In PR #3  I only built the `cli` and `shared` and ran those respective tests only.  In this PR, I did a `npm run build` and `npm test`.   Based on the summary output, `npm test` is all clear

```
$ npm test 2>&1 | grep -E "Test Files|Tests |Start at|Duration"
 Test Files  13 passed (13)
      Tests  161 passed (161)
   Start at  20:07:49
   Duration  414ms (transform 439ms, setup 0ms, collect 820ms, tests 42ms, environment 1ms, prepare 904ms)
 Test Files  34 passed (34)
      Tests  399 passed (399)
   Start at  20:07:49
   Duration  1.15s (transform 550ms, setup 0ms, collect 2.24s, tests 644ms, environment 3ms, prepare 2.42s)
 Test Files  68 passed (68)
      Tests  771 passed (771)
   Start at  20:07:51
   Duration  9.08s (transform 1.10s, setup 0ms, collect 8.96s, tests 13.21s, environment 7ms, prepare 4.30s)
   ✓ CLI Integration Tests > calm --version works  523ms
   ✓ CLI Integration Tests > calm init-ai -p copilot > creates correct directory structure and files  330ms
   ✓ CLI Integration Tests > Getting Started Verification - CLI Steps  711ms
   ✓ CLI Integration Tests > timeline command generates a timeline that calm validate --timeline can load  412ms
 Test Files  21 passed (21)
      Tests  548 passed (548)
   Start at  20:08:00
   Duration  15.01s (transform 1.64s, setup 0ms, collect 10.78s, tests 17.57s, environment 2ms, prepare 1.73s)
 Test Files  4 passed (4)
      Tests  11 passed (11)
   Start at  20:08:16
   Duration  1.36s (transform 238ms, setup 0ms, collect 1.93s, tests 283ms, environment 0ms, prepare 279ms)
 Test Files  59 passed (59)
      Tests  700 passed (700)
   Start at  20:08:18
   Duration  4.06s (transform 1.88s, setup 8.89s, collect 6.87s, tests 3.63s, environment 25.39s, prepare 3.25s)
 Test Files  26 passed (26)
      Tests  433 passed (433)
   Start at  20:08:22
   Duration  1.40s (transform 1.02s, setup 0ms, collect 4.26s, tests 327ms, environment 3ms, prepare 1.90s)
 Test Files  13 passed (13)
      Tests  111 passed (111)
   Start at  20:08:24
   Duration  7.27s (transform 827ms, setup 0ms, import 1.58s, tests 9.07s, environment 11.12s)
 Test Files  4 passed (4)
      Tests  66 passed (66)
   Start at  20:08:32
   Duration  310ms (transform 80ms, setup 0ms, collect 171ms, tests 14ms, environment 0ms, prepare 162ms)
 Test Files  4 passed (4)
      Tests  51 passed (51)
   Start at  20:08:33
   Duration  299ms (transform 97ms, setup 0ms, collect 312ms, tests 16ms, environment 0ms, prepare 133ms)
 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  20:08:33
   Duration  456ms (transform 65ms, setup 0ms, collect 26ms, tests 228ms, environment 0ms, prepare 31ms)
 Test Files  10 passed (10)
      Tests  79 passed (79)
   Start at  20:08:34
   Duration  519ms (transform 192ms, setup 0ms, collect 1.25s, tests 465ms, environment 1ms, prepare 507ms)
 Test Files  3 passed (3)
      Tests  21 passed (21)
   Start at  20:08:35
   Duration  418ms (transform 95ms, setup 0ms, collect 237ms, tests 6ms, environment 0ms, prepare 137ms)
 Test Files  2 passed (2)
      Tests  17 passed (17)
   Start at  20:08:36
   Duration  459ms (transform 71ms, setup 0ms, collect 183ms, tests 81ms, environment 0ms, prepare 69ms)
 Test Files  28 passed (28)
      Tests  419 passed (419)
   Start at  20:08:38
   Duration  2.64s (transform 2.61s, setup 0ms, collect 19.98s, tests 775ms, environment 9.07s, prepare 1.55s)
```

I'm hoping this address the CI errors for PR #3.  

If not, then we should have a chat about this.